### PR TITLE
gmailでのPWリセット機能

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,4 +90,25 @@ Rails.application.configure do
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("APP_HOST"),
+    protocol: "https"
+  }
+
+  # 本番でメール送信を有効化
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+
+  # Gmail SMTP
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              ENV.fetch("SMTP_ADDRESS"),
+    port:                 ENV.fetch("SMTP_PORT").to_i,
+    domain:               ENV.fetch("APP_HOST"),
+    user_name:            ENV.fetch("SMTP_USERNAME"),
+    password:             ENV.fetch("SMTP_PASSWORD"),
+    authentication:       "plain",
+    enable_starttls_auto: true
+  }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = ENV.fetch("MAILER_FROM")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
Closes #26

## 概要
Devise のパスワード再設定メールを SendGrid（SMTP）で本番環境から送信できるようにしました。

## 変更内容
- production の ActionMailer `default_url_options` を設定（メール内URLのホスト/https）
- SendGrid SMTP 設定を追加（環境変数参照）
- Devise の送信元（mailer_sender）を環境変数から設定

## 動作確認
- [ ] 本番（または staging）で「パスワードを忘れた」から送信できる
- [ ] 受信したメールのリセットURLが本番ホスト（APP_HOST）になっている
- [ ] リセットリンクからパスワード変更が完了できる

## 環境変数
- APP_HOST
- MAILER_FROM
- SMTP_ADDRESS=smtp.sendgrid.net
- SMTP_PORT=587
- SMTP_USERNAME=apikey
- SMTP_PASSWORD=(SendGrid API Key)

## 備考
- 秘密情報はコミットせず環境変数で管理しています。