### PR TITLE
Fix deploy: avoid missing env during assets:precompile

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,5 +310,5 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
-  config.mailer_sender = ENV.fetch("MAILER_FROM")
+  config.mailer_sender = ENV.fetch("MAILER_FROM", "dummy@example.com")
 end


### PR DESCRIPTION
（Docker build中）に config/initializers/devise.rb が読み込まれたとき、MAILER_FROM が未設定で ENV.fetch が落ちています。

KeyError: key not found: "MAILER_FROM"
.../config/initializers/devise.rb:313:in `fetch'


Docker build 中は Render の環境変数が入らないことがあるので、initializer は ENV が無くても落ちない書き方にする必要があります。

修正前（落ちる）
config.mailer_sender = ENV.fetch("MAILER_FROM")

修正後（落ちない）
config.mailer_sender = ENV.fetch("MAILER_FROM", "dummy@example.com")