### PR TITLE
"Fix deploy: avoid missing RESEND_API_KEY during assets:precompile"

### DIFF
--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,2 +1,2 @@
 require "resend"
-Resend.api_key = ENV.fetch("RESEND_API_KEY")
+Resend.api_key = ENV.fetch("RESEND_API_KEY", "dummy")


### PR DESCRIPTION
KeyError: key not found: "RESEND_API_KEY"
config/initializers/resend.rb:2:in `fetch'

デプロイエラーのため変更

# config/initializers/resend.rb
require "resend"

Resend.api_key = ENV.fetch("RESEND_API_KEY", "dummy")