### PR TITLE
フラッシュメッセージの確認とTurbo化

### DIFF
--- a/app/controllers/themes/rsvps_controller.rb
+++ b/app/controllers/themes/rsvps_controller.rb
@@ -1,15 +1,20 @@
 class Themes::RsvpsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_theme
+  respond_to :turbo_stream
 
   def update
     @rsvp = current_user.rsvps.find_or_initialize_by(theme: @theme)
 
-    if @rsvp.update(rsvp_params)
-      redirect_to @theme, notice: "参加状態を更新しました。"
-    else
-      redirect_to @theme, alert: "更新に失敗しました。"
-    end
+    updated = @rsvp.update(rsvp_params)
+    @rsvp_counts = @theme.rsvp_counts
+
+    message = updated ? "参加状態を更新しました。" : "更新に失敗しました。"
+    level = updated ? :notice : :alert
+    status = updated ? :ok : :unprocessable_entity
+
+    flash.now[level] = message
+    render :update, status: status
   end
 
   private

--- a/app/controllers/themes/theme_comments_controller.rb
+++ b/app/controllers/themes/theme_comments_controller.rb
@@ -9,12 +9,23 @@ module Themes
       # なりすまし防止：user_id は current_user から必ずセット
       @theme_comment.user = current_user
 
-      if @theme_comment.save
-        redirect_to theme_path(@theme), notice: "コメントを投稿しました。"
-      else
-        # show を render するために一覧用の変数も用意しておく
-        @theme_comments = @theme.theme_comments.includes(:user).order(created_at: :desc)
-        render "themes/show", status: :unprocessable_entity
+      saved = @theme_comment.save
+      load_theme_comments
+      @theme_comment = ThemeComment.new if saved
+
+      respond_to do |format|
+        format.html do
+          if saved
+            redirect_to theme_path(@theme), notice: "コメントを投稿しました。"
+          else
+            load_show_dependencies
+            render "themes/show", status: :unprocessable_entity
+          end
+        end
+        format.turbo_stream do
+          flash.now[:notice] = "コメントを投稿しました。" if saved
+          render :create, status: :unprocessable_entity unless saved
+        end
       end
     end
 
@@ -26,6 +37,15 @@ module Themes
 
     def theme_comment_params
       params.require(:theme_comment).permit(:body)
+    end
+
+    def load_theme_comments
+      @theme_comments = @theme.theme_comments.includes(:user).order(created_at: :desc)
+    end
+
+    def load_show_dependencies
+      @rsvp = current_user.rsvps.find_by(theme: @theme) if user_signed_in?
+      @rsvp_counts = @theme.rsvp_counts
     end
   end
 end

--- a/app/javascript/controllers/auto_dismiss_controller.js
+++ b/app/javascript/controllers/auto_dismiss_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { delay: Number }
+
+  connect() {
+    const delay = this.hasDelayValue ? this.delayValue : 5000
+    this.timeout = setTimeout(() => {
+      this.element.remove()
+    }, delay)
+  }
+
+  disconnect() {
+    if (this.timeout) {
+      clearTimeout(this.timeout)
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,4 +1,6 @@
 import { application } from "controllers/application"
+import AutoDismissController from "controllers/auto_dismiss_controller"
 import SecondaryButtonController from "controllers/secondary_button_controller"
 
+application.register("auto-dismiss", AutoDismissController)
 application.register("secondary-button", SecondaryButtonController)

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -6,4 +6,12 @@ class Rsvp < ApplicationRecord
 
   validates :status, presence: true
   validates :user_id, uniqueness: { scope: :theme_id }
+
+  before_validation :set_default_status, on: :create
+
+  private
+
+  def set_default_status
+    self.status ||= :undecided
+  end
 end

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,5 +1,7 @@
 ﻿<% if resource.errors.any? %>
-  <div role="alert" class="alert alert-error my-4" data-turbo-cache="false">
+  <div role="alert" class="alert alert-error my-4" data-turbo-cache="false"
+       data-controller="auto-dismiss"
+       data-auto-dismiss-delay-value="5000">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
     <div>
       <h3 class="font-bold">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,20 +57,8 @@
       </div>
     </header>
 
-    <div class="mx-auto w-full max-w-5xl px-4">
-      <% if notice.present? %>
-        <div role="alert" class="alert alert-success mt-4 shadow-md">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-          <span class="font-medium"><%= notice %></span>
-        </div>
-      <% end %>
-
-      <% if alert.present? %>
-        <div role="alert" class="alert alert-error mt-4 shadow-md">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-          <span class="font-medium"><%= alert %></span>
-        </div>
-      <% end %>
+    <div id="flash" class="fixed left-0 right-0 top-16 z-40">
+      <%= render "shared/flash" %>
     </div>
 
     <main class="mx-auto w-full max-w-5xl flex-1 px-4 py-8">

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,21 @@
+<% if notice.present? || alert.present? %>
+  <div class="mx-auto w-full max-w-5xl px-4">
+    <% if notice.present? %>
+      <div role="alert" class="alert alert-success mt-4 shadow-md"
+           data-controller="auto-dismiss"
+           data-auto-dismiss-delay-value="5000">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+        <span class="font-medium"><%= notice %></span>
+      </div>
+    <% end %>
+
+    <% if alert.present? %>
+      <div role="alert" class="alert alert-error mt-4 shadow-md"
+           data-controller="auto-dismiss"
+           data-auto-dismiss-delay-value="5000">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+        <span class="font-medium"><%= alert %></span>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/themes/_comment_form.html.erb
+++ b/app/views/themes/_comment_form.html.erb
@@ -1,0 +1,28 @@
+<%= turbo_frame_tag dom_id(theme, :comment_form) do %>
+  <% if theme_comment&.errors&.any? %>
+    <div role="alert" class="alert alert-error my-4"
+         data-controller="auto-dismiss"
+         data-auto-dismiss-delay-value="5000">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+      <div>
+        <h3 class="font-bold">入力内容を確認してください</h3>
+        <ul class="list-inside list-disc text-sm">
+          <% theme_comment.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+
+  <!-- Comment Form -->
+  <div class="mt-4">
+    <%= form_with model: [theme, theme_comment], class: "space-y-3" do |f| %>
+      <%= f.text_area :body, rows: 4, placeholder: "このテーマに対する意見や補足情報を入力してください",
+            class: "textarea textarea-bordered w-full ring-1 ring-base-300 focus:ring-2 focus:ring-primary" %>
+      <div class="flex justify-end">
+        <%= f.submit "コメントを投稿", class: "btn btn-neutral" %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/themes/_comments_list.html.erb
+++ b/app/views/themes/_comments_list.html.erb
@@ -1,0 +1,13 @@
+<%= turbo_frame_tag dom_id(theme, :comments) do %>
+  <div class="divider">コメント一覧</div>
+  <% if theme_comments.any? %>
+    <div class="space-y-4">
+      <%= render partial: "theme_comments/theme_comment", collection: theme_comments, as: :theme_comment %>
+    </div>
+  <% else %>
+    <div class="py-8 text-center">
+      <svg xmlns="http://www.w3.org/2000/svg" class="mx-auto h-12 w-12 text-base-content/30" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>
+      <p class="mt-3 text-base-content/60">まだコメントはありません。最初のコメントを投稿してみましょう。</p>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/themes/_form.html.erb
+++ b/app/views/themes/_form.html.erb
@@ -1,6 +1,8 @@
 <%= form_with model: theme, class: "space-y-6" do |f| %>
   <% if theme.errors.any? %>
-    <div role="alert" class="alert alert-error">
+    <div role="alert" class="alert alert-error"
+         data-controller="auto-dismiss"
+         data-auto-dismiss-delay-value="5000">
       <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
       <div>
         <h3 class="font-bold">入力内容を確認してください</h3>

--- a/app/views/themes/_rsvp_section.html.erb
+++ b/app/views/themes/_rsvp_section.html.erb
@@ -1,0 +1,48 @@
+<%= turbo_frame_tag dom_id(theme, :rsvp) do %>
+  <!-- RSVP Section -->
+  <% if user_signed_in? %>
+    <% current_status = rsvp&.status %>
+    <% secondary_on = rsvp&.secondary_interest? || false %>
+
+    <div class="divider">参加表明</div>
+
+    <div class="flex flex-wrap gap-2">
+      <%= button_to "参加", theme_rsvp_path(theme), method: :patch,
+            params: { rsvp: { status: :attending } },
+            class: "btn #{current_status == 'attending' ? 'btn-success' : 'btn-outline btn-success'}",
+            form: { data: { turbo_stream: true } } %>
+      <%= button_to "不参加", theme_rsvp_path(theme), method: :patch,
+            params: { rsvp: { status: :not_attending } },
+            class: "btn #{current_status == 'not_attending' ? 'btn-error' : 'btn-outline btn-error'}",
+            form: { data: { turbo_stream: true } } %>
+      <%= button_to "未定", theme_rsvp_path(theme), method: :patch,
+            params: { rsvp: { status: :undecided } },
+            class: "btn #{current_status == 'undecided' ? 'btn-warning' : 'btn-outline btn-warning'}",
+            form: { data: { turbo_stream: true } } %>
+    </div>
+
+    <div class="mt-3 flex gap-4 text-sm text-base-content/60">
+      <span>参加: <%= rsvp_counts[:attending] %></span>
+      <span>不参加: <%= rsvp_counts[:not_attending] %></span>
+      <span>未定: <%= rsvp_counts[:undecided] %></span>
+    </div>
+
+    <% if theme.secondary_enabled? %>
+      <% secondary_label = theme.secondary_label.presence || "第2ボタン" %>
+      <% next_secondary = !secondary_on %>
+      <div class="mt-4">
+        <%= button_to "#{secondary_label}（#{secondary_on ? 'ON' : 'OFF'}）",
+              theme_rsvp_path(theme), method: :patch,
+              params: { rsvp: { secondary_interest: next_secondary } },
+              class: "btn #{secondary_on ? 'btn-accent' : 'btn-outline btn-accent'}",
+              form: { data: { turbo_stream: true } } %>
+      </div>
+    <% end %>
+  <% else %>
+    <div role="alert" class="alert mt-4">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-5 w-5 shrink-0 stroke-info"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+      <span>参加状態の変更にはログインが必要です。</span>
+      <%= link_to "ログイン", new_user_session_path, class: "btn btn-sm btn-primary" %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/themes/_vote_section.html.erb
+++ b/app/views/themes/_vote_section.html.erb
@@ -1,0 +1,21 @@
+<%= turbo_frame_tag dom_id(theme, :vote) do %>
+  <div class="card card-compact bg-base-200 shadow-sm ring-1 ring-base-300">
+    <div class="card-body items-center text-center">
+      <span class="text-3xl font-bold text-primary"><%= theme.theme_votes.count %></span>
+      <span class="text-xs text-base-content/60">投票</span>
+      <% if user_signed_in? %>
+        <% voted = current_user.theme_votes.exists?(theme: theme) %>
+        <% if voted %>
+          <%= button_to "投票を取り消す", theme_vote_path(theme), method: :delete,
+                class: "btn btn-outline btn-sm mt-2", form_class: "inline" %>
+        <% else %>
+          <%= button_to "このテーマに投票", theme_vote_path(theme), method: :post,
+                class: "btn btn-primary btn-sm mt-2", form_class: "inline" %>
+        <% end %>
+      <% else %>
+        <%= link_to "ログインして投票", new_user_session_path,
+              class: "btn btn-primary btn-sm mt-2" %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/themes/rsvps/update.turbo_stream.erb
+++ b/app/views/themes/rsvps/update.turbo_stream.erb
@@ -1,0 +1,9 @@
+<% if flash.any? %>
+  <%= turbo_stream.update "flash" do %>
+    <%= render "shared/flash" %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.replace dom_id(@theme, :rsvp) do %>
+  <%= render "themes/rsvp_section", theme: @theme, rsvp: @rsvp, rsvp_counts: @rsvp_counts %>
+<% end %>

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -17,26 +17,7 @@
         <h1 class="text-2xl font-bold"><%= @theme.title %></h1>
       </div>
 
-      <!-- Vote Section -->
-      <div class="card card-compact bg-base-200 shadow-sm ring-1 ring-base-300">
-        <div class="card-body items-center text-center">
-          <span class="text-3xl font-bold text-primary"><%= @theme.theme_votes.count %></span>
-          <span class="text-xs text-base-content/60">投票</span>
-          <% if user_signed_in? %>
-            <% voted = current_user.theme_votes.exists?(theme: @theme) %>
-            <% if voted %>
-              <%= button_to "投票を取り消す", theme_vote_path(@theme), method: :delete,
-                    class: "btn btn-outline btn-sm mt-2", form_class: "inline" %>
-            <% else %>
-              <%= button_to "このテーマに投票", theme_vote_path(@theme), method: :post,
-                    class: "btn btn-primary btn-sm mt-2", form_class: "inline" %>
-            <% end %>
-          <% else %>
-            <%= link_to "ログインして投票", new_user_session_path,
-                  class: "btn btn-primary btn-sm mt-2" %>
-          <% end %>
-        </div>
-      </div>
+      <%= render "themes/vote_section", theme: @theme %>
     </header>
 
     <div class="divider"></div>
@@ -52,85 +33,11 @@
   <div class="card-body">
     <h2 class="card-title">コメント</h2>
 
-    <% if @theme_comment&.errors&.any? %>
-      <div role="alert" class="alert alert-error my-4">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-        <div>
-          <h3 class="font-bold">入力内容を確認してください</h3>
-          <ul class="list-inside list-disc text-sm">
-            <% @theme_comment.errors.full_messages.each do |msg| %>
-              <li><%= msg %></li>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-    <% end %>
+    <%= render "themes/comment_form", theme: @theme, theme_comment: @theme_comment %>
 
-    <!-- Comment Form -->
-    <div class="mt-4">
-      <%= form_with model: [@theme, @theme_comment], class: "space-y-3" do |f| %>
-        <%= f.text_area :body, rows: 4, placeholder: "このテーマに対する意見や補足情報を入力してください",
-              class: "textarea textarea-bordered w-full ring-1 ring-base-300 focus:ring-2 focus:ring-primary" %>
-        <div class="flex justify-end">
-          <%= f.submit "コメントを投稿", class: "btn btn-neutral" %>
-        </div>
-      <% end %>
-    </div>
-
-    <!-- RSVP Section -->
-    <% if user_signed_in? %>
-      <% current_status = @rsvp&.status %>
-      <% secondary_on = @rsvp&.secondary_interest? || false %>
-
-      <div class="divider">参加表明</div>
-
-      <div class="flex flex-wrap gap-2">
-        <%= button_to "参加", theme_rsvp_path(@theme), method: :patch,
-              params: { rsvp: { status: :attending } },
-              class: "btn #{current_status == 'attending' ? 'btn-success' : 'btn-outline btn-success'}" %>
-        <%= button_to "不参加", theme_rsvp_path(@theme), method: :patch,
-              params: { rsvp: { status: :not_attending } },
-              class: "btn #{current_status == 'not_attending' ? 'btn-error' : 'btn-outline btn-error'}" %>
-        <%= button_to "未定", theme_rsvp_path(@theme), method: :patch,
-              params: { rsvp: { status: :undecided } },
-              class: "btn #{current_status == 'undecided' ? 'btn-warning' : 'btn-outline btn-warning'}" %>
-      </div>
-
-      <div class="mt-3 flex gap-4 text-sm text-base-content/60">
-        <span>参加: <%= @rsvp_counts[:attending] %></span>
-        <span>不参加: <%= @rsvp_counts[:not_attending] %></span>
-        <span>未定: <%= @rsvp_counts[:undecided] %></span>
-      </div>
-
-      <% if @theme.secondary_enabled? %>
-        <% secondary_label = @theme.secondary_label.presence || "第2ボタン" %>
-        <% next_secondary = !secondary_on %>
-        <div class="mt-4">
-          <%= button_to "#{secondary_label}（#{secondary_on ? 'ON' : 'OFF'}）",
-                theme_rsvp_path(@theme), method: :patch,
-                params: { rsvp: { secondary_interest: next_secondary } },
-                class: "btn #{secondary_on ? 'btn-accent' : 'btn-outline btn-accent'}" %>
-        </div>
-      <% end %>
-    <% else %>
-      <div role="alert" class="alert mt-4">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-5 w-5 shrink-0 stroke-info"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-        <span>参加状態の変更にはログインが必要です。</span>
-        <%= link_to "ログイン", new_user_session_path, class: "btn btn-sm btn-primary" %>
-      </div>
-    <% end %>
+    <%= render "themes/rsvp_section", theme: @theme, rsvp: @rsvp, rsvp_counts: @rsvp_counts %>
 
     <!-- Comments List -->
-    <div class="divider">コメント一覧</div>
-    <% if @theme_comments.any? %>
-      <div class="space-y-4">
-        <%= render @theme_comments %>
-      </div>
-    <% else %>
-      <div class="py-8 text-center">
-        <svg xmlns="http://www.w3.org/2000/svg" class="mx-auto h-12 w-12 text-base-content/30" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>
-        <p class="mt-3 text-base-content/60">まだコメントはありません。最初のコメントを投稿してみましょう。</p>
-      </div>
-    <% end %>
+    <%= render "themes/comments_list", theme: @theme, theme_comments: @theme_comments %>
   </div>
 </div>

--- a/app/views/themes/theme_comments/create.turbo_stream.erb
+++ b/app/views/themes/theme_comments/create.turbo_stream.erb
@@ -1,0 +1,13 @@
+<% if flash.any? %>
+  <%= turbo_stream.update "flash" do %>
+    <%= render "shared/flash" %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.replace dom_id(@theme, :comment_form) do %>
+  <%= render "themes/comment_form", theme: @theme, theme_comment: @theme_comment %>
+<% end %>
+
+<%= turbo_stream.replace dom_id(@theme, :comments) do %>
+  <%= render "themes/comments_list", theme: @theme, theme_comments: @theme_comments %>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,20 @@
+ja:
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      blank: "を入力してください"
+      too_long: "は%{count}文字以内で入力してください"
+      required: "を入力してください"
+  activerecord:
+    models:
+      theme: "テーマ"
+      theme_comment: "コメント"
+    attributes:
+      theme:
+        category: "カテゴリ"
+        title: "タイトル"
+        description: "説明"
+        secondary_label: "第2ボタン名"
+        community: "コミュニティ"
+      theme_comment:
+        body: "コメント"


### PR DESCRIPTION
タイトル:
コメント/参加表明のTurbo更新とフラッシュ表示の改善

概要:
- コメント投稿を Turbo Stream 対応し、フォーム/一覧/フラッシュを即時更新
- RSVP 更新を Turbo Stream 専用にし、成功/失敗メッセージを即時表示
- 第2ボタンのみでも保存できるよう RSVP のデフォルト status を補完
- フラッシュ表示を部分化・固定表示・5秒自動消去に変更
- バリデーションの日本語メッセージを追加

影響/注意点:
- RSVP 更新は Turbo Stream 前提（HTML フォールバック無し）
- フラッシュは画面上部に固定表示
