### PR TITLE
ログイン画面にニックネームの欄を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,5 +8,6 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:account_update, keys: %i[nickname cohort])
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[nickname cohort])
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,6 +11,25 @@
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered w-full ring-1 ring-base-300 focus:ring-2 focus:ring-primary" %>
         </fieldset>
 
+        <div class="form-control mt-4">
+          <%= f.label :nickname, "ニックネーム", class: "label" %>
+          <%= f.text_field :nickname, class: "input input-bordered w-full", autocomplete: "nickname" %>
+        </div>
+
+        <div class="form-control mt-4">
+          <%= f.label :cohort, "期", class: "label" %>
+
+            <div class="flex items-center gap-2">
+              <%= f.number_field :cohort,
+                class: "input input-bordered w-32",
+                min: 1,
+                step: 1,
+                inputmode: "numeric" %>
+              <span class="text-base-content/70">期</span>
+            </div>
+        </div>
+
+
         <fieldset class="fieldset mt-4">
           <div class="flex items-center gap-2">
             <%= f.label :password, class: "fieldset-legend" %>
@@ -20,6 +39,7 @@
           </div>
           <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered w-full ring-1 ring-base-300 focus:ring-2 focus:ring-primary" %>
         </fieldset>
+
 
         <fieldset class="fieldset mt-4">
           <%= f.label :password_confirmation, "パスワード（確認）", class: "fieldset-legend" %>


### PR DESCRIPTION
Closed #42 

## 概要
サインアップ時点でプロフィール情報（ニックネーム / 期）を入力できるようにし、デフォルト値のユーザーが増えないようにしました。

## 変更内容
- Devise の sign_up で `nickname` / `cohort` を許可（permitted params 追加）
- Devise の account_update でも `nickname` / `cohort` を許可（既存の編集画面実装と整合）
- `devise/registrations/new` にフォーム入力欄を追加
  - ニックネーム：テキスト入力
  - 期：数値入力（number_field）＋「期」は表示のみ（ユーザーは数字のみ入力）

## 動作確認
- [ ] サインアップ画面に「ニックネーム」「期（数値入力 + 期表示）」が表示される
- [ ] ニックネームを入力して登録すると保存される
- [ ] 期を数字で入力して登録すると保存される
- [ ] 期が文字入力できず表記ゆれが起きない（数値入力のみ）

## 補足
- 既存ユーザー向けの default 対応は Issue A 側で対応済み前提のため、本PRでは追加していません