### PR TITLE
feat: ホームページに期とカテゴリで絞り込み可能な参加可能時間集計パネルを追加しました。

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,17 @@
 class HomeController < ApplicationController
-  def index
+    def index
+    # パラメータ（無ければデフォルト）
+    @cohort   = params.fetch(:cohort, "all")
+    @category = params.fetch(:category, "tech")
+    @category = "tech" unless %w[tech community].include?(@category)
+
+    # セレクト用（存在する期だけ出す）
+    @cohort_options = User.distinct.order(:cohort).pluck(:cohort).compact
+
+    # 集計（共通基盤を呼ぶ）
+    @availability_counts = Availability::AggregateCounts.call(
+      cohort: @cohort,
+      category: @category
+    )
   end
 end

--- a/app/services/availability/aggregate_counts.rb
+++ b/app/services/availability/aggregate_counts.rb
@@ -1,0 +1,54 @@
+require "set"
+
+module Availability
+  class AggregateCounts
+    SLOTS_PER_DAY = 48
+    WDAYS = 0..6
+
+    # cohort: "all" または 数値（StringでもOK）
+    # category: "tech" / "community"
+    def self.call(cohort:, category:)
+      cohort_value = normalize_cohort(cohort)
+      category_value = category.to_s
+
+      # 0件でも安定するように 7×48 の Set 配列を先に作る
+      seen = empty_seen_matrix
+
+      relation = AvailabilitySlot.where(category: category_value)
+
+      # cohort が all 以外なら users.cohort で絞る
+      if cohort_value
+        relation = relation.joins(:user).where(users: { cohort: cohort_value })
+      end
+
+      # 必要最小限のカラムだけ読む
+      relation.select(:id, :user_id, :wday, :start_minute, :end_minute).find_each do |slot|
+        wday = slot.wday
+        next unless WDAYS.cover?(wday)
+
+        start_idx = (slot.start_minute.to_i / 30).clamp(0, SLOTS_PER_DAY)
+        end_idx   = (slot.end_minute.to_i / 30).clamp(0, SLOTS_PER_DAY)
+
+        # end は「ちょうど端」なので含めない（start...end）
+        (start_idx...end_idx).each do |i|
+          seen[wday][i].add(slot.user_id)
+        end
+      end
+
+      # Set のサイズに変換して counts を作る
+      seen.map { |row| row.map(&:size) }
+    end
+
+    def self.normalize_cohort(cohort)
+      s = cohort.to_s
+      return nil if s.blank? || s == "all"
+      s.to_i
+    end
+
+    def self.empty_seen_matrix
+      Array.new(7) { Array.new(SLOTS_PER_DAY) { Set.new } }
+    end
+
+    private_class_method :normalize_cohort, :empty_seen_matrix
+  end
+end

--- a/app/views/availability/_aggregate_panel.html.erb
+++ b/app/views/availability/_aggregate_panel.html.erb
@@ -1,0 +1,55 @@
+<% wday_labels = %w[日 月 火 水 木 金 土] %>
+<% time_labels = (0..47).map do |i|
+     m = i * 30
+     format("%02d:%02d", m / 60, m % 60)
+   end %>
+
+<div class="rounded-lg border bg-white p-4 shadow-sm">
+  <div class="mb-3 flex items-center justify-between gap-3">
+    <h2 class="text-lg font-bold">参加可能時間（集計）</h2>
+
+    <%= form_with url: url, method: :get, local: true, class: "flex flex-wrap items-center gap-2" do %>
+      <label class="text-sm text-gray-600">期</label>
+      <%= select_tag :cohort,
+            options_for_select([["全員", "all"]] + cohort_options.map { |n| ["#{n}期", n] }, cohort),
+            class: "select select-bordered select-sm" %>
+
+      <label class="text-sm text-gray-600">カテゴリ</label>
+      <%= select_tag :category,
+            options_for_select([["Tech", "tech"], ["Community", "community"]], category),
+            class: "select select-bordered select-sm" %>
+
+      <%= submit_tag "表示", class: "btn btn-sm" %>
+    <% end %>
+  </div>
+
+  <div class="overflow-auto max-h-[70vh] rounded border">
+    <table class="min-w-full border-collapse text-sm">
+      <thead class="sticky top-0 bg-gray-50">
+        <tr>
+          <th class="border px-2 py-1 text-left">時間</th>
+          <% 0.upto(6) do |wday| %>
+            <th class="border px-2 py-1 text-center"><%= wday_labels[wday] %></th>
+          <% end %>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% time_labels.each_with_index do |t, i| %>
+          <tr>
+            <th class="border px-2 py-1 text-left bg-gray-50"><%= t %></th>
+            <% 0.upto(6) do |wday| %>
+              <td class="border px-2 py-1 text-center">
+                <%= counts[wday][i] %>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <p class="mt-2 text-xs text-gray-500">
+    表示は「枠ごとの人数」です（個人は特定しません）。同一ユーザーは同一枠で1人としてカウントします。
+  </p>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -54,4 +54,12 @@
       <p class="text-sm text-base-content/70">需要と参加人数を見て、主催者が開催を決定します。</p>
     </div>
   </div>
+
+  <%= render "availability/aggregate_panel",
+  url: request.path,
+  counts: @availability_counts,
+  cohort: @cohort,
+  category: @category,
+  cohort_options: @cohort_options
+  %>
 </section>


### PR DESCRIPTION
Closes #48

## 背景 / 目的
全ユーザー（または同一期）の参加可能時間を「個人特定なしの人数集計」として算出し、トップ画面・テーマ詳細画面で再利用できる共通基盤を整備する。
MVPとして、まずトップ画面で集計結果を最低限表示できる状態にする。

## 変更内容
- `Availability::AggregateCounts` を追加し、cohort/category 指定で **曜日×30分枠（7×48）** の人数集計を生成できるようにした
  - 同一ユーザーの重複スロットは **同一枠で1人としてカウント**（二重カウント防止）
  - データ0件でも **7×48の0配列** を返す（表示側が安定）
- トップ画面で集計結果を最低限表示できるようにした
  - controller で集計を呼び、view で表形式に描画
  - cohort/category を GET パラメータ（簡易フォーム）で切り替え可能

## 実装メモ
- 集計は `AvailabilitySlot` を cohort/category で絞り込み、30分枠に展開して `Set` に `user_id` を追加する方式で重複排除しています。
- 将来的に multi-community 対応時は community スコープを追加する想定です。

## 追加/変更した主なファイル
- `app/services/availability/aggregate_counts.rb`
- `app/controllers/home_controller.rb`
- `app/views/availability/_aggregate_panel.html.erb`
- `app/views/home/index.html.erb`（partial 呼び出しを追加）

## 動作確認
- トップ画面で集計表が表示されること
  - `/` を開く
- cohort / category の切替ができること（GET）
  - `/?cohort=all&category=tech`
  - `/?cohort=all&category=community`
  - `/?cohort=1&category=tech`（該当期が存在する場合）
- 集計が 0 件でも表示が崩れず、全セルが 0 で描画されること
- 同一ユーザーが重複する時間帯を登録しても、同一枠で人数が二重に増えないこと（表示上の人数で確認）

## スクリーンショット（任意）
- トップ画面の集計表（cohort/category 切替後の表示）