### PR TITLE
テーマ詳細画面に集計を表示する導線を追加

### DIFF
--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -58,11 +58,12 @@ class ThemesController < ApplicationController
     @theme = Theme.find(params[:id])
   end
 
-  # #49: テーマ詳細用の「同カテゴリ集計（期切替）」データを準備
+  # #49/#50: テーマ詳細用の「同カテゴリ集計（期切替）」データを準備
   def prepare_availability_aggregate
-    @cohort = params.fetch(:cohort, "all")
+    # ?cohort= が空のときも "all" 扱いにしてUI選択状態を安定させる
+    @cohort = params[:cohort].presence || "all"
 
-    @availability_category = @theme.category.to_s
+    @availability_category  = @theme.category.to_s
     @availability_supported = %w[tech community].include?(@availability_category)
 
     return unless @availability_supported

--- a/app/views/availability/_aggregate_panel.html.erb
+++ b/app/views/availability/_aggregate_panel.html.erb
@@ -1,4 +1,3 @@
-<%# オプション：テーマ詳細では show_category_select: false を渡す %>
 <% show_category_select = local_assigns.fetch(:show_category_select, true) %>
 
 <% wday_labels = %w[日 月 火 水 木 金 土] %>
@@ -7,38 +6,47 @@
      format("%02d:%02d", m / 60, m % 60)
    end %>
 
-<div class="rounded-lg border bg-white p-4 shadow-sm">
+<% cohort_options = Array(cohort_options).compact %>
+<% selected_cohort = cohort.to_s %>
+<% selected_category = category.to_s %>
+
+<% safe_counts = counts.presence || Array.new(7) { Array.new(48, 0) } %>
+
+<div class="rounded-lg border border-base-300 bg-base-100 p-4 shadow-sm">
   <div class="mb-3 flex items-center justify-between gap-3">
     <h2 class="text-lg font-bold">参加可能時間（集計）</h2>
 
     <%= form_with url: url, method: :get, local: true, class: "flex flex-wrap items-center gap-2" do %>
-      <label class="text-sm text-gray-600">期</label>
+      <label class="text-sm text-base-content/60">期</label>
+      <% cohort_select_options =
+           [["全員", "all"]] + cohort_options.map { |n| ["#{n}期", n.to_s] }
+      %>
       <%= select_tag :cohort,
-            options_for_select([["全員", "all"]] + cohort_options.map { |n| ["#{n}期", n] }, cohort),
+            options_for_select(cohort_select_options, selected_cohort),
             class: "select select-bordered select-sm" %>
 
       <% if show_category_select %>
-        <label class="text-sm text-gray-600">カテゴリ</label>
+        <label class="text-sm text-base-content/60">カテゴリ</label>
         <%= select_tag :category,
-              options_for_select([["Tech", "tech"], ["Community", "community"]], category),
+              options_for_select([["Tech", "tech"], ["Community", "community"]], selected_category),
               class: "select select-bordered select-sm" %>
       <% else %>
-        <%# テーマ詳細ではカテゴリ固定（表示だけ） %>
-        <span class="text-sm text-gray-600">カテゴリ</span>
-        <span class="text-sm font-medium"><%= category.to_s.capitalize %></span>
+        <%= hidden_field_tag :category, selected_category %>
+        <span class="text-sm text-base-content/60">カテゴリ</span>
+        <span class="text-sm font-medium"><%= selected_category.capitalize %></span>
       <% end %>
 
       <%= submit_tag "表示", class: "btn btn-sm" %>
     <% end %>
   </div>
 
-  <div class="overflow-auto max-h-[70vh] rounded border">
+  <div class="overflow-auto max-h-[70vh] rounded border border-base-300">
     <table class="min-w-full border-collapse text-sm">
-      <thead class="sticky top-0 bg-gray-50">
+      <thead class="sticky top-0 bg-base-200">
         <tr>
-          <th class="border px-2 py-1 text-left">時間</th>
+          <th class="border border-base-300 px-2 py-1 text-left">時間</th>
           <% 0.upto(6) do |wday| %>
-            <th class="border px-2 py-1 text-center"><%= wday_labels[wday] %></th>
+            <th class="border border-base-300 px-2 py-1 text-center"><%= wday_labels[wday] %></th>
           <% end %>
         </tr>
       </thead>
@@ -46,10 +54,10 @@
       <tbody>
         <% time_labels.each_with_index do |t, i| %>
           <tr>
-            <th class="border px-2 py-1 text-left bg-gray-50"><%= t %></th>
+            <th class="border border-base-300 px-2 py-1 text-left bg-base-200"><%= t %></th>
             <% 0.upto(6) do |wday| %>
-              <td class="border px-2 py-1 text-center">
-                <%= counts[wday][i] %>
+              <td class="border border-base-300 px-2 py-1 text-center">
+                <%= safe_counts[wday][i] %>
               </td>
             <% end %>
           </tr>
@@ -58,7 +66,7 @@
     </table>
   </div>
 
-  <p class="mt-2 text-xs text-gray-500">
+  <p class="mt-2 text-xs text-base-content/60">
     表示は「枠ごとの人数」です（個人は特定しません）。同一ユーザーは同一枠で1人としてカウントします。
   </p>
 </div>

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -43,8 +43,9 @@
     <h2 class="card-title">コメント</h2>
 
     <%= render "themes/comment_form", theme: @theme, theme_comment: @theme_comment %>
-    <% if @availability_supported %>
-      <div class="mt-4">
+
+    <div class="mt-4">
+      <% if @availability_supported %>
         <%= render "availability/aggregate_panel",
           url: theme_path(@theme),
           counts: @availability_counts,
@@ -53,13 +54,13 @@
           cohort_options: @cohort_options,
           show_category_select: false
         %>
-      </div>
-    <% else %>
-      <div class="mt-4 rounded-lg border bg-white p-4 shadow-sm">
-        <h2 class="text-lg font-bold">参加可能時間（同カテゴリ集計）</h2>
-        <p class="mt-1 text-sm text-gray-600">このカテゴリは集計対象外です。</p>
-      </div>
-    <% end %>
+      <% else %>
+        <div class="rounded-lg border border-base-300 bg-base-100 p-4">
+          <h2 class="text-lg font-bold">参加可能時間（同カテゴリ集計）</h2>
+          <p class="mt-1 text-sm text-base-content/60">このカテゴリは集計対象外です。</p>
+        </div>
+      <% end %>
+    </div>
 
     <%= render "themes/rsvp_section", theme: @theme, rsvp: @rsvp, rsvp_counts: @rsvp_counts %>
 


### PR DESCRIPTION
## 概要
テーマ詳細ページに「同カテゴリの参加可能時間（集計）」を表示できるようにしました。
期（cohort）を切り替えることで、表示対象の期を変更できます。

## 背景 / 目的
テーマごとに「そのカテゴリで参加できる人がどれくらいいるか」を、テーマ詳細の文脈で確認できるようにするため。

## 変更内容
- テーマ詳細（themes#show）で集計データを準備し、集計パネルを表示
- テーマのカテゴリに合わせて **集計カテゴリを固定**（テーマ詳細ではカテゴリ選択を表示しない）
- tech/community のみ集計表示し、それ以外は「対象外」メッセージを表示
- cohort（期）を切り替え可能（`?cohort=all` / `?cohort=1` など）
- 0件でも崩れないように、counts/cohort_options の nil ガードを追加
- テーマ詳細でカテゴリ固定のとき、フォーム送信時にカテゴリが落ちないよう hidden で保持

## 実装メモ（ざっくり構造）
themes/show
  └─ prepare_availability_aggregate
       ├─ cohort を決定（空なら all）
       ├─ テーマカテゴリが tech/community のみ集計
       └─ Availability::AggregateCounts で counts(7×48) を作成
  └─ view で aggregate_panel を再利用（テーマ詳細はカテゴリselectなし）

## 変更した主なファイル
- app/controllers/themes_controller.rb
  - prepare_availability_aggregate の追加/調整（cohort・カテゴリ固定・対象外判定・options準備）
- app/views/themes/show.html.erb
  - 集計パネルをテーマ詳細に組み込み（show_category_select: false）
  - 対象外カテゴリの表示を追加
- app/views/availability/_aggregate_panel.html.erb
  - テーマ詳細（カテゴリ固定）用の表示/hidden対応
  - cohort_options / counts の nil ガード、選択状態の安定化（to_s統一）

## 動作確認
- [ ] tech/community のテーマ詳細で「参加可能時間（集計）」が表示される
- [ ] 期を切り替えると表示が切り替わる（URLに `?cohort=` が付く）
- [ ] 対象外カテゴリ（例: youtube）のテーマ詳細では対象外メッセージが出る
- [ ] availability_slots が0件でも表示が崩れない
- [ ] 同一ユーザーの重複登録が人数に二重計上されない（同一枠は1人）

Closes #50