### PR TITLE
feat: 参加可能時間の集計表示パネルと開発用起動スクリプト、およびガイダンス・ホーム画面を追加

### DIFF
--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -1,4 +1,6 @@
 module AvailabilityHelper
+  WDAY_LABELS = %w[日 月 火 水 木 金 土].freeze
+
   def minutes_to_hhmm(min)
     h = min / 60
     m = min % 60
@@ -7,5 +9,27 @@ module AvailabilityHelper
 
   def range_to_label(range)
     "#{minutes_to_hhmm(range[:start_minute])}〜#{minutes_to_hhmm(range[:end_minute])}"
+  end
+
+  # 集計カレンダー用：人数に応じたセルのCSSクラスを決定
+  # @param count [Integer] 参加可能人数
+  # @return [String] TailwindCSSクラス
+  def aggregate_cell_class_for_count(count)
+    case count
+    when 0 then "bg-base-100 text-base-content/20"
+    when 1..2 then "bg-sky-100 text-sky-800"
+    when 3..5 then "bg-sky-300 text-sky-900"
+    when 6..8 then "bg-sky-500 text-white font-medium"
+    else "bg-sky-700 text-white font-bold"
+    end
+  end
+
+  # 集計カレンダー用：セルのツールチップテキストを生成
+  # @param wday [Integer] 曜日インデックス（0=日曜）
+  # @param time_label [String] 時間ラベル（例: "09:00"）
+  # @param count [Integer] 参加可能人数
+  # @return [String] ツールチップテキスト
+  def aggregate_cell_tooltip(wday, time_label, count)
+    "#{WDAY_LABELS[wday]} #{time_label} - #{count}人"
   end
 end

--- a/app/views/availability/_aggregate_panel.html.erb
+++ b/app/views/availability/_aggregate_panel.html.erb
@@ -1,10 +1,6 @@
 <% show_category_select = local_assigns.fetch(:show_category_select, true) %>
 
-<% wday_labels = %w[日 月 火 水 木 金 土] %>
-<% time_labels = (0..47).map do |i|
-     m = i * 30
-     format("%02d:%02d", m / 60, m % 60)
-   end %>
+<% wday_labels = AvailabilityHelper::WDAY_LABELS %>
 
 <% cohort_options = Array(cohort_options).compact %>
 <% selected_cohort = cohort.to_s %>
@@ -13,7 +9,7 @@
 <% safe_counts = counts.presence || Array.new(7) { Array.new(48, 0) } %>
 
 <div class="rounded-lg border border-base-300 bg-base-100 p-4 shadow-sm">
-  <div class="mb-3 flex items-center justify-between gap-3">
+  <div class="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
     <h2 class="text-lg font-bold">参加可能時間（集計）</h2>
 
     <%= form_with url: url, method: :get, local: true, class: "flex flex-wrap items-center gap-2" do %>
@@ -40,33 +36,108 @@
     <% end %>
   </div>
 
-  <div class="overflow-auto max-h-[70vh] rounded border border-base-300">
-    <table class="min-w-full border-collapse text-sm">
-      <thead class="sticky top-0 bg-base-200">
-        <tr>
-          <th class="border border-base-300 px-2 py-1 text-left">時間</th>
-          <% 0.upto(6) do |wday| %>
-            <th class="border border-base-300 px-2 py-1 text-center"><%= wday_labels[wday] %></th>
+  <%# 凡例（レジェンド） %>
+  <div class="mb-3 flex flex-wrap items-center gap-3 text-xs">
+    <span class="text-base-content/60 font-medium">凡例:</span>
+    <span class="inline-flex items-center gap-1">
+      <span class="inline-block h-4 w-4 rounded border border-base-300 bg-base-100"></span>
+      <span class="text-base-content/60">0人</span>
+    </span>
+    <span class="inline-flex items-center gap-1">
+      <span class="inline-block h-4 w-4 rounded border border-sky-200 bg-sky-100"></span>
+      <span>1-2人</span>
+    </span>
+    <span class="inline-flex items-center gap-1">
+      <span class="inline-block h-4 w-4 rounded border border-sky-300 bg-sky-300"></span>
+      <span>3-5人</span>
+    </span>
+    <span class="inline-flex items-center gap-1">
+      <span class="inline-block h-4 w-4 rounded border border-sky-500 bg-sky-500"></span>
+      <span>6-8人</span>
+    </span>
+    <span class="inline-flex items-center gap-1">
+      <span class="inline-block h-4 w-4 rounded border border-sky-700 bg-sky-700"></span>
+      <span>9人+</span>
+    </span>
+  </div>
+
+  <%# ガントチャート風表示 %>
+  <div class="overflow-x-auto rounded-lg border-2 border-base-300">
+    <table class="w-full border-collapse" style="min-width: 900px;">
+      <%# ヘッダー（2時間単位、4列結合） %>
+      <thead>
+        <tr class="bg-base-200">
+          <th rowspan="2" class="border-r-2 border-b-2 border-base-300 px-2 py-2 text-sm font-bold text-center w-12">曜日</th>
+          <% 0.step(22, 2) do |hour| %>
+            <th colspan="4" class="border-r-2 border-b border-base-300 py-1 text-center text-xs font-bold <%= hour % 6 == 0 ? 'bg-base-300/50' : '' %>">
+              <%= hour %>〜<%= hour + 2 %>時
+            </th>
+          <% end %>
+        </tr>
+        <%# サブヘッダー（30分単位） %>
+        <tr class="bg-base-200/50">
+          <% 0.upto(47) do |slot| %>
+            <% hour = slot / 2 %>
+            <% minute = (slot % 2) * 30 %>
+            <% is_block_start = slot % 4 == 0 %>
+            <th class="<%= is_block_start ? 'border-l-2 border-l-base-300' : 'border-l border-l-base-300/30' %> border-b-2 border-r border-r-base-300/30 border-base-300 py-1 text-center text-[10px] font-normal text-base-content/60" style="min-width: 18px;">
+              <%= minute == 0 ? format("%d", hour) : '' %>
+            </th>
           <% end %>
         </tr>
       </thead>
 
+      <%# 各曜日の行 %>
       <tbody>
-        <% time_labels.each_with_index do |t, i| %>
-          <tr>
-            <th class="border border-base-300 px-2 py-1 text-left bg-base-200"><%= t %></th>
-            <% 0.upto(6) do |wday| %>
-              <td class="border border-base-300 px-2 py-1 text-center">
-                <%= safe_counts[wday][i] %>
+        <% 0.upto(6) do |wday| %>
+          <tr class="hover:bg-base-100/30 transition-colors">
+            <%# 曜日ラベル %>
+            <th class="border-r-2 border-b-2 border-base-300 px-2 py-2 text-sm font-bold bg-base-200 text-center <%= [0, 6].include?(wday) ? 'text-error' : '' %>">
+              <%= wday_labels[wday] %>
+            </th>
+
+            <%# 時間枠（30分単位） %>
+            <% 0.upto(47) do |slot| %>
+              <% count = safe_counts[wday][slot] %>
+              <% hour = slot / 2 %>
+              <% minute = (slot % 2) * 30 %>
+              <% time_label = format("%02d:%02d", hour, minute) %>
+              <% is_block_start = slot % 4 == 0 %>
+              <td class="<%= is_block_start ? 'border-l-2 border-l-base-300' : 'border-l border-l-base-300/30' %> border-b-2 border-base-300 p-0 text-center">
+                <div class="group relative h-10 w-full <%= aggregate_cell_class_for_count(count) %> flex items-center justify-center cursor-default transition-all hover:brightness-110 hover:z-10">
+                  <% if count > 0 %>
+                    <span class="font-bold text-xs"><%= count %></span>
+                  <% end %>
+
+                  <%# カスタムツールチップ（下に表示） %>
+                  <div class="absolute top-full left-1/2 -translate-x-1/2 mt-2 px-3 py-2 bg-neutral text-neutral-content text-xs rounded-lg shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-[100] whitespace-nowrap pointer-events-none">
+                    <%# 上向き矢印 %>
+                    <div class="absolute bottom-full left-1/2 -translate-x-1/2 border-4 border-transparent border-b-neutral"></div>
+                    <div class="font-bold text-sm"><%= wday_labels[wday] %>曜日 <%= time_label %></div>
+                    <div class="mt-1">参加可能: <span class="text-sky-400 font-bold"><%= count %>人</span></div>
+                  </div>
+                </div>
               </td>
             <% end %>
           </tr>
         <% end %>
       </tbody>
+
+      <%# フッター（2時間単位） %>
+      <tfoot>
+        <tr class="bg-base-200">
+          <th class="border-r-2 border-base-300 px-2 py-1 text-sm font-bold text-center">時間</th>
+          <% 0.step(22, 2) do |hour| %>
+            <th colspan="4" class="border-r-2 border-base-300 py-1 text-center text-xs font-bold <%= hour % 6 == 0 ? 'bg-base-300/50' : '' %>">
+              <%= hour %>〜<%= hour + 2 %>時
+            </th>
+          <% end %>
+        </tr>
+      </tfoot>
     </table>
   </div>
 
   <p class="mt-2 text-xs text-base-content/60">
-    表示は「枠ごとの人数」です（個人は特定しません）。同一ユーザーは同一枠で1人としてカウントします。
+    各セルは30分の枠を表示。マウスを乗せると詳細が確認できます。
   </p>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,8 +1,8 @@
 <!-- Hero Section -->
-<section class="hero min-h-[50vh] rounded-box bg-base-100 shadow-xl">
-  <div class="hero-content py-16 text-center">
+<section class="hero min-h-[40vh] rounded-box bg-gradient-to-br from-base-100 to-base-200 shadow-xl">
+  <div class="hero-content py-12 text-center">
     <div class="max-w-2xl">
-      <div class="badge badge-primary badge-outline mb-4">企画支援サービス</div>
+      <div class="badge badge-primary badge-lg mb-4 shadow">企画支援サービス</div>
       <h1 class="text-4xl font-extrabold leading-tight md:text-5xl">
         やりたいテーマを集めて、<br class="hidden md:inline">開催の意思決定を後押し
       </h1>
@@ -29,37 +29,48 @@
   </div>
 </section>
 
-<!-- Features Section -->
-<section class="mt-12 grid gap-6 md:grid-cols-3">
-  <div class="card bg-base-100 shadow-md ring-1 ring-base-300 transition-shadow hover:shadow-xl">
-    <div class="card-body items-center text-center">
-      <div class="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-primary text-xl font-bold text-primary-content">1</div>
-      <h2 class="card-title">テーマ投稿</h2>
-      <p class="text-sm text-base-content/70">カテゴリ・タイトル・概要を投稿して、やりたい企画を提案します。</p>
+<!-- How It Works Section -->
+<section class="mt-12">
+  <h2 class="text-2xl font-bold text-center mb-6">
+    <span class="text-primary">KikakuHub</span>の使い方
+  </h2>
+  <div class="grid gap-6 md:grid-cols-3">
+    <div class="card bg-base-100 shadow-md ring-1 ring-base-300 transition-all hover:shadow-xl hover:-translate-y-1">
+      <div class="card-body items-center text-center">
+        <div class="mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-2xl font-bold text-primary-content shadow-lg">1</div>
+        <h3 class="card-title">テーマ投稿</h3>
+        <p class="text-sm text-base-content/70">カテゴリ・タイトル・概要を投稿して、やりたい企画を提案します。</p>
+      </div>
+    </div>
+
+    <div class="card bg-base-100 shadow-md ring-1 ring-base-300 transition-all hover:shadow-xl hover:-translate-y-1">
+      <div class="card-body items-center text-center">
+        <div class="mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-secondary text-2xl font-bold text-secondary-content shadow-lg">2</div>
+        <h3 class="card-title">投票・参加表明</h3>
+        <p class="text-sm text-base-content/70">気になるテーマに投票し、参加意思を表明して需要を可視化します。</p>
+      </div>
+    </div>
+
+    <div class="card bg-base-100 shadow-md ring-1 ring-base-300 transition-all hover:shadow-xl hover:-translate-y-1">
+      <div class="card-body items-center text-center">
+        <div class="mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-accent text-2xl font-bold text-accent-content shadow-lg">3</div>
+        <h3 class="card-title">開催判断</h3>
+        <p class="text-sm text-base-content/70">需要と参加人数を見て、主催者が開催を決定します。</p>
+      </div>
     </div>
   </div>
+</section>
 
-  <div class="card bg-base-100 shadow-md ring-1 ring-base-300 transition-shadow hover:shadow-xl">
-    <div class="card-body items-center text-center">
-      <div class="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-secondary text-xl font-bold text-secondary-content">2</div>
-      <h2 class="card-title">投票・参加表明</h2>
-      <p class="text-sm text-base-content/70">気になるテーマに投票し、参加意思を表明して需要を可視化します。</p>
-    </div>
-  </div>
-
-  <div class="card bg-base-100 shadow-md ring-1 ring-base-300 transition-shadow hover:shadow-xl">
-    <div class="card-body items-center text-center">
-      <div class="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-accent text-xl font-bold text-accent-content">3</div>
-      <h2 class="card-title">開催判断</h2>
-      <p class="text-sm text-base-content/70">需要と参加人数を見て、主催者が開催を決定します。</p>
-    </div>
-  </div>
-
+<!-- Availability Aggregate Section -->
+<section class="mt-12">
+  <h2 class="text-2xl font-bold text-center mb-6">
+    <span class="text-sky-600">参加可能時間</span>の集計
+  </h2>
   <%= render "availability/aggregate_panel",
-  url: request.path,
-  counts: @availability_counts,
-  cohort: @cohort,
-  category: @category,
-  cohort_options: @cohort_options
+      url: request.path,
+      counts: @availability_counts,
+      cohort: @cohort,
+      category: @category,
+      cohort_options: @cohort_options
   %>
 </section>

--- a/app/views/static_pages/guidance.html.erb
+++ b/app/views/static_pages/guidance.html.erb
@@ -59,7 +59,7 @@
                    <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z" />
                 </svg>
              </div>
-            <h3 class="card-title flex flex-wrap justify-center gap-2">日程調整が面倒 <span class="badge badge-sm badge-ghost font-normal align-middle">Coming Soon（気持ち的には）</span></h3>
+            <h3 class="card-title">日程調整が面倒</h3>
             <p class="text-sm opacity-70">参加者の予定を聞いて回るのが大変で、心が折れてしまう。</p>
           </div>
         </div>
@@ -127,12 +127,11 @@
         </div>
         <div class="card bg-base-100 shadow-lg border-l-4 border-accent hover:shadow-xl transition-all duration-300">
           <div class="card-body">
-            <h3 class="card-title text-accent flex flex-wrap items-center gap-2">
+            <h3 class="card-title text-accent">
                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
                </svg>
-               <span>参加可能時間の集計</span>
-               <span class="badge badge-sm badge-accent font-normal align-middle">Coming Soon（気持ち的には）</span>
+               参加可能時間の集計
             </h3>
             <p>個人の予定は公開せず、コミュニティ全体の「暇な時間」だけをヒートマップのように可視化します。</p>
           </div>


### PR DESCRIPTION
## 背景・目的 (Why)
集計された参加可能人数を直感的に把握できるようにするため、カレンダーの表示を改善します。
数値の羅列ではなく、人数の多さに応じで色の濃淡が変わるヒートマップ形式を採用し、ユーザー体験を向上させます。
## 変更内容 (What)
### UI/UX改善
- **ヒートマップ風配色**: 参加人数に応じて背景色を「青色(Sky)」ベースで5段階に変化させるスタイルを適用。
  - 0人: 色なし
  - 1-2人: 薄い青
  - 3-5人: 中間の青
  - 6-8人: 濃い青
  - 9人以上: 最も濃い青
- **カスタムツールチップ**: 各セルにマウスオーバーした際、曜日・時間・具体的な人数を表示するツールチップを追加。
- **凡例（レジェンド）**: 色分けの意味を示す凡例をカレンダー上部に追加。
- **レイアウト調整**: 横スクロール(`overflow-x-auto`)に対応し、画面幅が狭い場合でも表が崩れないように調整。
### コードの整理
- **Helperへのロジック移動**: ビュー内に記述されていたスタイル条件分岐を `AvailabilityHelper#aggregate_cell_class_for_count` として切り出し、可読性を向上。
## 動作確認 (Verification)
- [ ] カレンダーが表示され、人数が入っているセルに色が及んでいること。
- [ ] 人数が多いセルほど色が濃くなっていること（凡例と一致していること）。
- [ ] セルにマウスカーソルを乗せた際、詳細情報のツールチップがポップアップ表示されること。
- [ ] 画面幅を縮めた際、カレンダーが横スクロール可能になりレイアウトが崩れないこと。

<img width="1739" height="948" alt="image" src="https://github.com/user-attachments/assets/f2475aca-997c-496b-b253-1c6b355564be" />
