### PR TITLE
参加時間集計のカテゴリ切り替えの非同期化

### DIFF
--- a/app/javascript/controllers/auto_submit_controller.js
+++ b/app/javascript/controllers/auto_submit_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  submit() {
+    this.element.requestSubmit()
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,8 +3,10 @@ import AutoDismissController from "controllers/auto_dismiss_controller"
 import SecondaryButtonController from "controllers/secondary_button_controller"
 import AvailabilityDraftController from "controllers/availability_draft_controller"
 import AvailabilitySlotsController from "controllers/availability_slots_controller"
+import AutoSubmitController from "controllers/auto_submit_controller"
 
 application.register("auto-dismiss", AutoDismissController)
 application.register("secondary-button", SecondaryButtonController)
 application.register("availability-draft", AvailabilityDraftController)
 application.register("availability-slots", AvailabilitySlotsController)
+application.register("auto-submit", AutoSubmitController)

--- a/app/views/availability/_aggregate_frame.html.erb
+++ b/app/views/availability/_aggregate_frame.html.erb
@@ -1,0 +1,11 @@
+<% show_category_select = local_assigns.fetch(:show_category_select, true) %>
+
+<%= turbo_frame_tag "availability_aggregate", data: { turbo_action: "advance" } do %>
+  <%= render "availability/aggregate_panel",
+        url: url,
+        counts: counts,
+        cohort: cohort,
+        category: category,
+        cohort_options: cohort_options,
+        show_category_select: show_category_select %>
+<% end %>

--- a/app/views/availability/_aggregate_panel.html.erb
+++ b/app/views/availability/_aggregate_panel.html.erb
@@ -12,23 +12,28 @@
   <div class="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
     <h2 class="text-lg font-bold">参加可能時間（集計）</h2>
 
-    <%= form_with url: url, method: :get, local: true, class: "flex flex-wrap items-center gap-2" do %>
+    <%= form_with url: url,
+              method: :get,
+              data: { turbo_frame: "availability_aggregate", controller: "auto-submit" },
+              class: "flex flex-wrap items-center gap-2" do %>
       <label class="text-sm text-base-content/60">期</label>
       <% cohort_select_options =
            [["全員", "all"]] + cohort_options.map { |n| ["#{n}期", n.to_s] }
       %>
       <%= select_tag :cohort,
-            options_for_select(cohort_select_options, selected_cohort),
-            class: "select select-bordered select-sm" %>
+      options_for_select(cohort_select_options, selected_cohort),
+      class: "select select-bordered select-sm",
+      data: { action: "change->auto-submit#submit" } %>
 
       <% if show_category_select %>
         <label class="text-sm text-base-content/60">カテゴリ</label>
         <%= select_tag :category,
-              options_for_select( 
-                Theme.categories.keys.map { |k| [Theme.human_enum_name(:category, k), k] },
-                selected_category
-              ),
-              class: "select select-bordered select-sm" %>
+      options_for_select(
+        Theme.categories.keys.map { |k| [Theme.human_enum_name(:category, k), k] },
+        selected_category
+      ),
+      class: "select select-bordered select-sm",
+      data: { action: "change->auto-submit#submit" } %>
       <% else %>
         <%= hidden_field_tag :category, selected_category %>
         <span class="text-sm text-base-content/60">カテゴリ</span>
@@ -38,8 +43,11 @@
                 "未選択" %>
         </span>
       <% end %>
-
-      <%= submit_tag "表示", class: "btn btn-sm" %>
+      <noscript>
+        <div class="mt-2">
+          <%= submit_tag "表示", class: "btn btn-sm" %>
+        </div>
+      </noscript>
     <% end %>
   </div>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -82,7 +82,7 @@
   <h2 class="text-2xl font-bold text-center mb-6">
     <span class="text-sky-600">みんなの参加可能時間</span>
   </h2>
-  <%= render "availability/aggregate_panel",
+  <%= render "availability/aggregate_frame",
       url: request.path,
       counts: @availability_counts,
       cohort: @cohort,

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -48,7 +48,7 @@
 
     <div class="mt-4">
       <% if @availability_supported %>
-        <%= render "availability/aggregate_panel",
+        <%= render "availability/aggregate_frame",
           url: theme_path(@theme),
           counts: @availability_counts,
           cohort: @cohort,


### PR DESCRIPTION
## 概要（Why）
参加可能時間（集計）の「期・カテゴリ」切替でページ全体が再読み込みされて操作感が重かったため、**集計パネル部分のみを非同期で更新**できるようにしました。

## 変更内容（What）
- Turbo Frames を用いて、集計パネルを **部分更新**できるように変更
  - `app/views/availability/_aggregate_frame.html.erb` を追加（`turbo_frame_tag "availability_aggregate"`）
- 集計パネルのフォームをフレーム内更新に対応
  - `app/views/availability/_aggregate_panel.html.erb` のフォームに `data-turbo-frame="availability_aggregate"` 等を付与
  - 期/カテゴリの `select` 変更で自動送信するため、Stimulus を追加
- 自動送信用 Stimulus コントローラ追加
  - `app/javascript/controllers/auto_submit_controller.js`
- 呼び出し側を `aggregate_panel` → `aggregate_frame` に差し替え
  - `app/views/home/index.html.erb`
  - `app/views/themes/show.html.erb`

## 仕様メモ
- 期/カテゴリを変更すると **集計パネルのみ**が更新されます（ページ全体はリロードしません）
- クエリ（`cohort` / `category`）がURLに反映され、リロードしても同じ状態が復元されます
- 「表示」ボタンは、非同期化に伴い削除しました（UI簡略化）

## 動作確認（How）
1. ホーム画面の集計パネルで「期」「カテゴリ」を変更
   - ページ全体がリロードされず、集計表だけ更新されること
   - URLのクエリが更新されること
2. テーマ詳細画面（集計表示が出るカテゴリ）でも同様に切替できること
3. 連続で変更しても崩れないこと（表示が壊れない / エラーにならない）

## 影響範囲
- 参加可能時間（集計）の表示・切替UIのみ（保存ロジック等には影響なし）

Close #69
