### PR TITLE
AvailabilitySlotsControllerのリファクタリング（サービスクラス抽出）

### DIFF
--- a/app/services/availability/bulk_create_slots.rb
+++ b/app/services/availability/bulk_create_slots.rb
@@ -4,15 +4,15 @@ module Availability
       new(user:, category:, wdays:, start_minute:, end_minute:).call
     end
 
-    # "HH:MM" -> minutes
     def self.time_to_minutes(value)
-      return nil if value.blank?
-      return value if value.is_a?(Integer)
+      Availability::TimeConverter.time_to_minutes(value)
+    end
 
-      m = value.to_s.match(/(\d{1,2}):(\d{2})/)
-      return nil unless m
-
-      m[1].to_i * 60 + m[2].to_i
+    def self.validate_inputs(wdays:, start_minute:, end_minute:)
+      return "曜日を選択してください" if wdays.blank?
+      return "開始時刻/終了時刻を選択してください" if start_minute.nil? || end_minute.nil?
+      return "開始時刻は終了時刻より前にしてください" if start_minute >= end_minute
+      nil
     end
 
     def initialize(user:, category:, wdays:, start_minute:, end_minute:)

--- a/app/services/availability/bulk_update_slots.rb
+++ b/app/services/availability/bulk_update_slots.rb
@@ -1,0 +1,53 @@
+module Availability
+  class BulkUpdateSlots
+    def self.call(user:, category:, slots_param:)
+      new(user:, category:, slots_param:).call
+    end
+
+    def initialize(user:, category:, slots_param:)
+      @user = user
+      @category = category
+      @slots_param = slots_param
+    end
+
+    def call
+      slots_hash = normalize_slots_hash(@slots_param)
+
+      ActiveRecord::Base.transaction do
+        slots_hash.each do |key, attrs|
+          attrs = attrs.to_unsafe_h if attrs.is_a?(ActionController::Parameters)
+          p = ActionController::Parameters.new(attrs).permit(:start_time, :end_time, :wday, :category)
+
+          start_minute = Availability::TimeConverter.time_to_minutes(p[:start_time])
+          end_minute   = Availability::TimeConverter.time_to_minutes(p[:end_time])
+
+          if key.to_s.start_with?("new_")
+            next if start_minute.nil? || end_minute.nil?
+            next if start_minute >= end_minute
+
+            @user.availability_slots.create!(
+              wday: p[:wday].to_i,
+              category: (p[:category].presence || @category),
+              start_minute: start_minute,
+              end_minute: end_minute
+            )
+          else
+            slot = @user.availability_slots.find(key)
+            raise ActiveRecord::RecordInvalid.new(slot) if start_minute.nil? || end_minute.nil? || start_minute >= end_minute
+            slot.update!(start_minute: start_minute, end_minute: end_minute)
+          end
+        end
+
+        Availability::WeeklySlotNormalizer.call(user: @user, category: @category)
+      end
+    end
+
+    private
+
+    def normalize_slots_hash(slots_param)
+      h = slots_param || {}
+      h = h.to_unsafe_h if h.is_a?(ActionController::Parameters)
+      h
+    end
+  end
+end

--- a/app/services/availability/time_converter.rb
+++ b/app/services/availability/time_converter.rb
@@ -1,0 +1,14 @@
+module Availability
+  module TimeConverter
+    # "HH:MM" -> minutes (Integer) or nil
+    def self.time_to_minutes(value)
+      return nil if value.blank?
+      return value if value.is_a?(Integer)
+
+      m = value.to_s.match(/(\d{1,2}):(\d{2})/)
+      return nil unless m
+
+      m[1].to_i * 60 + m[2].to_i
+    end
+  end
+end


### PR DESCRIPTION
## 概要（Why）
`Profiles::AvailabilitySlotsController`（169行）にビジネスロジック（一括更新処理、入力バリデーション、時間変換）が集中しており、テストしにくく保守性が低かったため、既存のサービスクラスパターンに合わせて責務を分離しました。

## 変更内容（What）
- `time_to_minutes` を共通モジュール `Availability::TimeConverter` に抽出
  - `BulkCreateSlots.time_to_minutes` は後方互換のため `TimeConverter` への委譲として維持
- `apply_bulk_update!` + `normalize_slots_hash` を `Availability::BulkUpdateSlots` サービスクラスに抽出
  - 既存の `BulkCreateSlots` と同じ `self.call` パターンで統一
- `validate_bulk_inputs` を `Availability::BulkCreateSlots.validate_inputs` クラスメソッドに移動
- フラッシュメッセージ組み立てロジックを `bulk_create_notice` / `overwrite_copy_notice` privateメソッドに整理

### Before / After
| 指標 | Before | After |
|------|--------|-------|
| コントローラ行数 | 169行 | 135行 |
| コントローラ内のビジネスロジック | 39行 | 0行 |
| サービスクラス数 | 4個 | 6個 |
| ルーティング変更 | - | なし |
| ビュー変更 | - | なし |

## 動作確認（How）
- [ ] 参加可能時間の一括追加（`bulk_create`）が既存通り動作すること
- [ ] 個別スロットの保存・更新（`bulk_update`）が既存通り動作すること
- [ ] スロットの削除（`destroy` / `destroy_all`）が既存通り動作すること
- [ ] カテゴリコピー（`overwrite_copy_category`）が既存通り動作すること
- [ ] エラー時のフラッシュメッセージが正しく表示されること

## 影響範囲
- Controller: `Profiles::AvailabilitySlotsController`（修正）
- Service: `Availability::TimeConverter`（新規）、`Availability::BulkUpdateSlots`（新規）、`Availability::BulkCreateSlots`（修正）
- ルーティング・ビューへの変更なし

Closes #74