### PR TITLE
ThemesControllerのデバッグログを削除

### DIFF
--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -26,10 +26,6 @@ class ThemesController < ApplicationController
     if @theme.save
       redirect_to @theme, notice: "テーマが作成されました。", status: :see_other
     else
-      Rails.logger.info("[debug] env=#{Rails.env} db=#{ActiveRecord::Base.connection_db_config.database}")
-      Rails.logger.info("[debug] community_id=#{@theme.community_id.inspect} exists=#{Community.exists?(@theme.community_id)}")
-      Rails.logger.info("[debug] errors=#{@theme.errors.full_messages}")
-
       flash.now[:alert] = "入力内容を確認してください"
       render :new, status: :unprocessable_entity
     end


### PR DESCRIPTION
## 概要
ThemesController#createのelseブロックに残されていたデバッグログ3行を削除しました。

## 変更内容
- `app/controllers/themes_controller.rb` 行29-31のデバッグログを削除
  - DB接続情報
  - community_id存在チェック
  - エラーメッセージ

## 理由
デバッグログでDB接続情報を出力することはセキュリティリスクとなるため。

## 検証
- [x] コードレビュー
- [ ] Rubocop確認（Docker環境起動後）
- [ ] テーマ作成機能の動作確認

Closes #76