### PR TITLE
I18n time.formats.short を定義し、rescue握りつぶしを削除

### DIFF
--- a/app/views/theme_comments/_theme_comment.html.erb
+++ b/app/views/theme_comments/_theme_comment.html.erb
@@ -4,7 +4,7 @@
     <div class="flex items-center justify-between gap-3">
       <div class="flex items-center gap-2">
         <p class="text-xs text-base-content/50">
-          <%= l(theme_comment.created_at, format: :short) rescue theme_comment.created_at.strftime("%Y-%m-%d %H:%M") %>
+          <%= l(theme_comment.created_at, format: :short) %>
         </p>
         <% if user_signed_in? && current_user == theme_comment.user %>
           <%= button_to "削除", theme_theme_comment_path(theme, theme_comment),

--- a/app/views/themes/index.html.erb
+++ b/app/views/themes/index.html.erb
@@ -25,7 +25,7 @@
             <div class="mb-2 flex flex-wrap items-center gap-2">
               <span class="badge badge-primary"><%= Theme.human_enum_name(:category, theme.category) %></span>
               <span class="text-xs text-base-content/60">
-                <%= l(theme.created_at, format: :short) rescue theme.created_at.to_s %>
+                <%= l(theme.created_at, format: :short) %>
               </span>
             </div>
 

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -13,7 +13,7 @@
         <div class="mb-2 flex flex-wrap items-center gap-2">
           <span class="badge badge-primary badge-lg"><%= Theme.human_enum_name(:category, @theme.category) %></span>
           <span class="text-sm text-base-content/60">
-            <%= l(@theme.created_at, format: :short) rescue @theme.created_at.to_s %>
+            <%= l(@theme.created_at, format: :short) %>
           </span>
         </div>
         <h1 class="text-2xl font-bold"><%= @theme.title %></h1>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,7 @@
 ja:
+  time:
+    formats:
+      short: "%Y-%m-%d %H:%M"
   errors:
     format: "%{attribute}%{message}"
     messages:


### PR DESCRIPTION
## 概要
複数のビューで使用されている `l(xxx, format: :short) rescue ...` のrescue握りつぶしを解消しました。

## 変更内容

### 1. I18nフォーマット定義追加
`config/locales/ja.yml` に `time.formats.short` を追加
```yaml
time:
  formats:
    short: "%Y-%m-%d %H:%M"
```

### 2. rescue削除
以下のビューから rescue を削除：
- `app/views/themes/index.html.erb` 行28
- `app/views/themes/show.html.erb` 行16
- `app/views/theme_comments/_theme_comment.html.erb` 行7

## 理由
`:short` フォーマットが未定義のためrescueで握りつぶしていたが、正しくフォーマットを定義することで、エラーを隠蔽せずに済む。

## 検証
- [ ] テーマ一覧で日時が `YYYY-MM-DD HH:MM` 形式で表示されることを確認
- [ ] テーマ詳細で日時が正しく表示されることを確認
- [ ] コメントの日時が正しく表示されることを確認

Closes #77