### PR TITLE
テーマ一覧のN+1クエリを解消（counter_cache導入）

### DIFF
--- a/app/models/theme_vote.rb
+++ b/app/models/theme_vote.rb
@@ -1,6 +1,6 @@
 class ThemeVote < ApplicationRecord
   belongs_to :user
-  belongs_to :theme
+  belongs_to :theme, counter_cache: true
 
   validates :user_id, uniqueness: { scope: :theme_id }
 end

--- a/app/views/themes/_vote_section.html.erb
+++ b/app/views/themes/_vote_section.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag dom_id(theme, :vote) do %>
   <div class="card card-compact bg-base-200 shadow-sm ring-1 ring-base-300">
     <div class="card-body items-center text-center">
-      <span class="text-3xl font-bold text-primary"><%= theme.theme_votes.count %></span>
+      <span class="text-3xl font-bold text-primary"><%= theme.theme_votes_count %></span>
       <span class="text-xs text-base-content/60">投票</span>
       <% if user_signed_in? %>
         <% voted = current_user.theme_votes.exists?(theme: theme) %>

--- a/app/views/themes/index.html.erb
+++ b/app/views/themes/index.html.erb
@@ -40,7 +40,7 @@
 
           <div class="flex shrink-0 flex-col items-end gap-2">
             <div class="rounded-lg bg-primary/10 px-3 py-1 text-center">
-              <span class="text-lg font-bold text-primary"><%= theme.theme_votes.count rescue 0 %></span>
+              <span class="text-lg font-bold text-primary"><%= theme.theme_votes_count %></span>
               <span class="block text-xs text-base-content/60">投票</span>
             </div>
             <%= link_to "詳細を見る", theme_path(theme),

--- a/db/migrate/20260206120627_add_theme_votes_count_to_themes.rb
+++ b/db/migrate/20260206120627_add_theme_votes_count_to_themes.rb
@@ -1,0 +1,14 @@
+class AddThemeVotesCountToThemes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :themes, :theme_votes_count, :integer, default: 0, null: false
+
+    # 既存データのカウンターキャッシュを初期化
+    reversible do |dir|
+      dir.up do
+        Theme.find_each do |theme|
+          Theme.reset_counters(theme.id, :theme_votes)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
テーマ一覧で `theme.theme_votes.count` を呼び出しており、N+1クエリが発生していました。counter_cacheを導入してパフォーマンスを改善しました。

## 変更内容

### 1. マイグレーション
`db/migrate/20260206120627_add_theme_votes_count_to_themes.rb`
- `themes` テーブルに `theme_votes_count` カラムを追加（default: 0, null: false）
- 既存データのカウンターキャッシュを `reset_counters` で初期化

### 2. モデル修正
`app/models/theme_vote.rb`
- `belongs_to :theme` に `counter_cache: true` オプションを追加

### 3. ビュー修正
- `app/views/themes/index.html.erb`: `theme.theme_votes.count rescue 0` → `theme.theme_votes_count`
- `app/views/themes/_vote_section.html.erb`: `theme.theme_votes.count` → `theme.theme_votes_count`

## 効果
テーマ一覧表示時に、テーマ数分のSELECT文が発行されていたN+1クエリが解消され、パフォーマンスが大幅に向上します。

## 検証
- [ ] マイグレーション実行: `docker compose exec web rails db:migrate`
- [ ] テーマ一覧表示時のSQLログでN+1が解消されていることを確認
- [ ] 投票数が正しく表示されることを確認
- [ ] 投票・投票取り消しでカウントが正しく更新されることを確認

Closes #78