### PR TITLE
Remove unused jbuilder gem and move browser-based debug tools to development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "sprockets-rails"
 gem "importmap-rails"
 gem "turbo-rails"
 gem "stimulus-rails"
-gem "jbuilder"
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 
@@ -31,8 +30,6 @@ group :development, :test do
 
   # デバッグツール
   gem "pry-byebug"
-  gem "better_errors"
-  gem "binding_of_caller"
 
   # テスト関連
   gem "rspec-rails"
@@ -48,4 +45,8 @@ group :development do
   gem "bullet"
 
   gem "letter_opener_web"
+
+  # ブラウザベースデバッグツール
+  gem "better_errors"
+  gem "binding_of_caller"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,9 +148,6 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.14.1)
-      actionview (>= 7.0.0)
-      activesupport (>= 7.0.0)
     json (2.18.0)
     language_server-protocol (3.17.0.5)
     launchy (3.1.1)
@@ -379,7 +376,6 @@ DEPENDENCIES
   factory_bot_rails
   faker
   importmap-rails
-  jbuilder
   letter_opener_web
   pg (~> 1.1)
   pry-byebug


### PR DESCRIPTION
## 概要
Gemfileの依存関係を整理し、未使用のgemを削除、開発専用ツールを適切なグループに移動しました。

## 変更内容
- `jbuilder` gemを削除（プロジェクトで未使用）
- `better_errors` と `binding_of_caller` を `:development, :test` グループから `:development` グループのみに移動
  - これらはブラウザベースのデバッグツールでテスト環境では使用しないため

## 動作確認
- ✅ `bundle install` 成功
- ✅ RuboCop違反なし

Closes #85