### PR TITLE
Extract category keys into Theme::CATEGORY_KEYS constant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@
 .github/instructions/
 .github/copilot-instructions.md
 docs/ai/
+.claude/
+CLAUDE.md
+*.claude.md

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,7 +3,7 @@ class HomeController < ApplicationController
     # パラメータ（無ければデフォルト）
     @cohort   = params.fetch(:cohort, "all")
     @category = params.fetch(:category, "tech")
-    @category = "tech" unless %w[tech community].include?(@category)
+    @category = "tech" unless Theme::CATEGORY_KEYS.include?(@category)
 
     # セレクト用（存在する期だけ出す）
     @cohort_options = User.distinct.order(:cohort).pluck(:cohort).compact

--- a/app/controllers/profiles/availability_slots_controller.rb
+++ b/app/controllers/profiles/availability_slots_controller.rb
@@ -3,13 +3,13 @@ module Profiles
     before_action :authenticate_user!
 
     def index
-      @category = params[:category].presence_in(%w[tech community]) || "tech"
+      @category = params[:category].presence_in(Theme::CATEGORY_KEYS) || "tech"
       slots = current_user.availability_slots.where(category: @category)
       @slots_by_wday = slots.group_by(&:wday)
     end
 
     def bulk_create
-      @category = bulk_params[:category].presence_in(%w[tech community]) || "tech"
+      @category = bulk_params[:category].presence_in(Theme::CATEGORY_KEYS) || "tech"
 
       wdays = Array(bulk_params[:wdays]).reject(&:blank?).map(&:to_i).uniq
       start_minute = Availability::TimeConverter.time_to_minutes(bulk_params[:start_time])
@@ -36,7 +36,7 @@ module Profiles
     end
 
     def bulk_update
-      @category = params[:category].presence_in(%w[tech community]) || "tech"
+      @category = params[:category].presence_in(Theme::CATEGORY_KEYS) || "tech"
 
       Availability::BulkUpdateSlots.call(
         user: current_user, category: @category, slots_param: params[:slots]
@@ -56,7 +56,7 @@ module Profiles
     end
 
     def overwrite_copy_category
-      from = params.require(:from_category).presence_in(%w[tech community]) || "tech"
+      from = params.require(:from_category).presence_in(Theme::CATEGORY_KEYS) || "tech"
       to   = (from == "tech" ? "community" : "tech")
 
       @category = from
@@ -87,7 +87,7 @@ module Profiles
     end
 
     def destroy_all
-      category = params.require(:category).presence_in(%w[tech community]) || "tech"
+      category = params.require(:category).presence_in(Theme::CATEGORY_KEYS) || "tech"
 
       deleted = current_user.availability_slots.where(category: category).delete_all
 

--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -60,7 +60,7 @@ class ThemesController < ApplicationController
     @cohort = params[:cohort].presence || "all"
 
     @availability_category  = @theme.category.to_s
-    @availability_supported = %w[tech community].include?(@availability_category)
+    @availability_supported = Theme::CATEGORY_KEYS.include?(@availability_category)
 
     return unless @availability_supported
 

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,4 +1,6 @@
 class Theme < ApplicationRecord
+  CATEGORY_KEYS = %w[tech community].freeze
+
   belongs_to :community
   belongs_to :user
 


### PR DESCRIPTION
## 概要
カテゴリキー配列のハードコードを排除し、Theme::CATEGORY_KEYS定数に統一しました。

## 変更内容
- **Themeモデル**: `CATEGORY_KEYS = %w[tech community].freeze`を定数として定義
- **3つのコントローラーの7箇所**でハードコードされていた配列を定数参照に置換:
  - `ThemesController#prepare_availability_aggregate`: 1箇所
  - `HomeController#index`: 1箇所
  - `Profiles::AvailabilitySlotsController`: 5箇所

## メリット
- カテゴリの追加・変更時に1箇所の修正で済む
- typoや不一致のリスク排除
- コードの保守性向上

## 動作確認
- ✅ RuboCop違反なし

Closes #79