### PR TITLE
Extract Themes::BaseController to eliminate duplication

### DIFF
--- a/app/controllers/themes/base_controller.rb
+++ b/app/controllers/themes/base_controller.rb
@@ -1,0 +1,12 @@
+module Themes
+  class BaseController < ApplicationController
+    before_action :authenticate_user!
+    before_action :set_theme
+
+    private
+
+    def set_theme
+      @theme = Theme.find(params[:theme_id])
+    end
+  end
+end

--- a/app/controllers/themes/rsvps_controller.rb
+++ b/app/controllers/themes/rsvps_controller.rb
@@ -1,29 +1,25 @@
-class Themes::RsvpsController < ApplicationController
-  before_action :authenticate_user!
-  before_action :set_theme
-  respond_to :turbo_stream
+module Themes
+  class RsvpsController < BaseController
+    respond_to :turbo_stream
 
-  def update
-    @rsvp = current_user.rsvps.find_or_initialize_by(theme: @theme)
+    def update
+      @rsvp = current_user.rsvps.find_or_initialize_by(theme: @theme)
 
-    updated = @rsvp.update(rsvp_params)
-    @rsvp_counts = @theme.rsvp_counts
+      updated = @rsvp.update(rsvp_params)
+      @rsvp_counts = @theme.rsvp_counts
 
-    message = updated ? "参加状態を更新しました。" : "更新に失敗しました。"
-    level = updated ? :notice : :alert
-    status = updated ? :ok : :unprocessable_entity
+      message = updated ? "参加状態を更新しました。" : "更新に失敗しました。"
+      level = updated ? :notice : :alert
+      status = updated ? :ok : :unprocessable_entity
 
-    flash.now[level] = message
-    render :update, status: status
-  end
+      flash.now[level] = message
+      render :update, status: status
+    end
 
-  private
+    private
 
-  def set_theme
-    @theme = Theme.find(params[:theme_id])
-  end
-
-  def rsvp_params
-    params.require(:rsvp).permit(:status, :secondary_interest)
+    def rsvp_params
+      params.require(:rsvp).permit(:status, :secondary_interest)
+    end
   end
 end

--- a/app/controllers/themes/theme_comments_controller.rb
+++ b/app/controllers/themes/theme_comments_controller.rb
@@ -1,7 +1,5 @@
 module Themes
-  class ThemeCommentsController < ApplicationController
-    before_action :authenticate_user!  # Devise: 未ログインならログイン画面へ
-    before_action :set_theme           # /themes/:theme_id を使って対象テーマを取得
+  class ThemeCommentsController < BaseController
     before_action :set_theme_comment, only: [ :destroy ]
 
     def create
@@ -51,10 +49,6 @@ module Themes
     end
 
     private
-
-    def set_theme
-      @theme = Theme.find(params[:theme_id])
-    end
 
     def theme_comment_params
       params.require(:theme_comment).permit(:body)

--- a/app/controllers/themes/votes_controller.rb
+++ b/app/controllers/themes/votes_controller.rb
@@ -1,8 +1,5 @@
 module Themes
-  class VotesController < ApplicationController
-    before_action :authenticate_user!
-    before_action :set_theme
-
+  class VotesController < BaseController
     def create
       begin
         current_user.theme_votes.create!(theme: @theme)
@@ -23,12 +20,6 @@ module Themes
         # 既に取消済み（連打など）でもOK
         redirect_to @theme, notice: "既に取り消し済みです"
       end
-    end
-
-    private
-
-    def set_theme
-      @theme = Theme.find(params[:theme_id])
     end
   end
 end


### PR DESCRIPTION
## 概要
themes名前空間の3つのコントローラーで重複していたコードを、Themes::BaseControllerに抽出しました。

## 変更内容

### 新規作成: Themes::BaseController
- `authenticate_user!` before_action
- `set_theme` before_action
- `set_theme` private method

### 重複コード削除
以下の3つのコントローラーで重複していたコードを削除:
- **Themes::RsvpsController**
  - before_action 2行削除
  - set_theme メソッド削除
- **Themes::ThemeCommentsController**
  - before_action 2行削除
  - set_theme メソッド削除
- **Themes::VotesController**
  - before_action 2行削除
  - set_theme メソッド削除

## メリット
- DRY原則の遵守
- 共通ロジックの一元管理
- 将来的な変更時の影響範囲の最小化
- コードの可読性向上

## 動作確認
- ✅ RuboCop違反なし

Closes #80