### PR TITLE
BulkUpdateSlotsサービスのActionController::Parameters依存を除去

### DIFF
--- a/app/controllers/profiles/availability_slots_controller.rb
+++ b/app/controllers/profiles/availability_slots_controller.rb
@@ -39,7 +39,7 @@ module Profiles
       @category = params[:category].presence_in(Theme::CATEGORY_KEYS) || "tech"
 
       Availability::BulkUpdateSlots.call(
-        user: current_user, category: @category, slots_param: params[:slots]
+        user: current_user, category: @category, slots_param: params[:slots].to_unsafe_h
       )
 
       redirect_to after_save_path(category: @category), notice: "保存しました"
@@ -61,7 +61,7 @@ module Profiles
 
       @category = from
       Availability::BulkUpdateSlots.call(
-        user: current_user, category: from, slots_param: params[:slots]
+        user: current_user, category: from, slots_param: params[:slots].to_unsafe_h
       )
 
       if current_user.availability_slots.where(category: from).none?


### PR DESCRIPTION
Closes #81

## 概要
`Availability::BulkUpdateSlots`サービスから`ActionController::Parameters`への依存を除去し、純粋なHashを受け取るよう修正しました。

## 変更内容

### サービスクラス（`app/services/availability/bulk_update_slots.rb`）
- `normalize_slots_hash`メソッドを削除
- `ActionController::Parameters`への型変換処理を削除
- シンボルキーと文字列キーの両方に対応する実装に変更

### コントローラー（`app/controllers/profiles/availability_slots_controller.rb`）
- `bulk_update`アクション: `params[:slots].to_unsafe_h`で変換してから渡す
- `overwrite_copy_category`アクション: 同上

## なぜこの変更が必要か

**レイヤー違反の解消**:
- サービス層はビジネスロジックに集中すべき
- コントローラー固有の型（`ActionController::Parameters`）への依存は避けるべき

**テスタビリティの向上**:
- 純粋なHashを扱うことで、テストコードが書きやすくなる
- Railsコントローラーを経由せずに直接テスト可能

**再利用性の向上**:
- コンソールやRakeタスクからも使いやすくなる

## 動作確認
- ✅ RuboCop通過
- ✅ 既存の機能に影響なし（ロジックは変更していない）