### PR TITLE
Communityモデルにバリデーションとアソシエーションを追加

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,3 +1,7 @@
 class Community < ApplicationRecord
   DEFAULT_ID = 1
+
+  has_many :themes, dependent: :restrict_with_error
+
+  validates :name, presence: true
 end

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -1,5 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe Community, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'associations' do
+    it { should have_many(:themes).dependent(:restrict_with_error) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+  end
+
+  describe 'constants' do
+    it 'has DEFAULT_ID constant' do
+      expect(Community::DEFAULT_ID).to eq(1)
+    end
+  end
+
+  describe 'dependent: :restrict_with_error' do
+    it 'テーマが存在する場合はコミュニティを削除できない' do
+      community = create(:community)
+      create(:theme, community: community)
+
+      expect { community.destroy }.not_to change(Community, :count)
+      expect(community.errors[:base]).to be_present
+    end
+
+    it 'テーマが存在しない場合はコミュニティを削除できる' do
+      community = create(:community)
+
+      expect { community.destroy }.to change(Community, :count).by(-1)
+    end
+  end
 end


### PR DESCRIPTION
Closes #84

## 概要
`Community`モデルにバリデーションとアソシエーションを追加し、適切なモデル定義を実装しました。

## 変更内容

### モデル（`app/models/community.rb`）
- `has_many :themes, dependent: :restrict_with_error` を追加
  - Themeモデルとの双方向アソシエーションを確立
  - テーマが存在する場合は削除を防止
- `validates :name, presence: true` を追加
  - コミュニティ名を必須化

### RSpecテスト（`spec/models/community_spec.rb`）
- アソシエーションのテスト
- バリデーションのテスト
- DEFAULT_ID定数のテスト
- `dependent: :restrict_with_error` の動作テスト

## なぜこの変更が必要か

**アソシエーションの欠落**:
- `Theme`モデルに `belongs_to :community` があるが、逆関連が未定義だった
- 双方向アソシエーションにより、コードの可読性と保守性が向上

**バリデーションの欠落**:
- `name`カラムがnullableだが、バリデーションがなかった
- データ整合性を保証するため必須化

**削除制約**:
- テーマが存在するコミュニティを削除すると孤立レコードが発生する
- `dependent: :restrict_with_error` により安全性を確保

## 動作確認
- ✅ RuboCop通過
- ✅ RSpec全テスト通過（5 examples, 0 failures）