### PR TITLE
ApplicationControllerにauthorize_owner!メソッドを抽出

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,11 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update, keys: %i[nickname cohort])
     devise_parameter_sanitizer.permit(:sign_up, keys: %i[nickname cohort])
   end
+
+  def authorize_owner!(resource, redirect_path = root_path)
+    unless resource.user == current_user
+      redirect_to redirect_path, alert: "削除権限がありません。", status: :see_other
+      nil
+    end
+  end
 end

--- a/app/controllers/themes/theme_comments_controller.rb
+++ b/app/controllers/themes/theme_comments_controller.rb
@@ -29,10 +29,7 @@ module Themes
     end
 
     def destroy
-      unless @theme_comment.user == current_user
-        redirect_to theme_path(@theme), alert: "削除権限がありません。", status: :see_other
-        return
-      end
+      authorize_owner!(@theme_comment, theme_path(@theme))
 
       if @theme_comment.destroy
         load_theme_comments

--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -32,10 +32,7 @@ class ThemesController < ApplicationController
   end
 
   def destroy
-    unless @theme.user == current_user
-      redirect_to theme_path(@theme), alert: "削除権限がありません。", status: :see_other
-      return
-    end
+    authorize_owner!(@theme, theme_path(@theme))
 
     if @theme.destroy
       redirect_to themes_path, notice: "テーマを削除しました。", status: :see_other


### PR DESCRIPTION
Closes #86

## 概要
複数のコントローラーで重複していた権限チェックロジックを`ApplicationController`に抽出しました。

## 変更内容

### ApplicationController
```ruby
def authorize_owner!(resource, redirect_path = root_path)
  unless resource.user == current_user
    redirect_to redirect_path, alert: "削除権限がありません。", status: :see_other
    nil
  end
end
```

### ThemesController#destroy
**Before**:
```ruby
def destroy
  unless @theme.user == current_user
    redirect_to theme_path(@theme), alert: "削除権限がありません。", status: :see_other
    return
  end
  # ...
end
```

**After**:
```ruby
def destroy
  authorize_owner!(@theme, theme_path(@theme))
  # ...
end
```

### ThemeCommentsController#destroy
同様に `authorize_owner!` を使用するよう変更

## なぜこの変更が必要か

**DRY原則の違反**:
- 2つのコントローラーで同じ権限チェックロジックが重複
- コードの保守性が低下（修正時に複数箇所を変更する必要）

**柔軟性の向上**:
- リダイレクト先を引数で指定可能
- デフォルトは `root_path`、必要に応じてカスタマイズ可能
- 将来的に他のコントローラーでも再利用可能

## 動作確認
- ✅ RuboCop通過
- ✅ 既存の動作を維持（リダイレクト先も同じ）