### PR TITLE
overwrite_copy_category!をサービス層に移動

### DIFF
--- a/app/controllers/profiles/availability_slots_controller.rb
+++ b/app/controllers/profiles/availability_slots_controller.rb
@@ -70,7 +70,7 @@ module Profiles
         return
       end
 
-      result = AvailabilitySlot.overwrite_copy_category!(
+      result = Availability::OverwriteCopyCategory.call(
         user: current_user,
         from_category: from,
         to_category: to

--- a/app/models/availability_slot.rb
+++ b/app/models/availability_slot.rb
@@ -31,33 +31,4 @@ class AvailabilitySlot < ApplicationRecord
     errors.add(:start_minute, "は30分単位で入力してください") unless (start_minute % 30).zero?
     errors.add(:end_minute, "は30分単位で入力してください") unless (end_minute % 30).zero?
   end
-
-  def self.overwrite_copy_category!(user:, from_category:, to_category:)
-    now = Time.current
-
-    rows = user.availability_slots
-               .where(category: from_category)
-               .pluck(:wday, :start_minute, :end_minute)
-               .uniq
-               .map do |wday, s, e|
-                 {
-                   user_id: user.id,
-                   category: to_category,
-                   wday: wday,
-                   start_minute: s,
-                   end_minute: e,
-                   created_at: now,
-                   updated_at: now
-                 }
-               end
-
-    deleted = 0
-
-    transaction do
-      deleted = user.availability_slots.where(category: to_category).delete_all
-      insert_all(rows) if rows.any?
-    end
-
-    { deleted: deleted, created: rows.size }
-  end
 end

--- a/app/services/availability/overwrite_copy_category.rb
+++ b/app/services/availability/overwrite_copy_category.rb
@@ -1,0 +1,42 @@
+module Availability
+  class OverwriteCopyCategory
+    def self.call(user:, from_category:, to_category:)
+      new(user:, from_category:, to_category:).call
+    end
+
+    def initialize(user:, from_category:, to_category:)
+      @user = user
+      @from_category = from_category
+      @to_category = to_category
+    end
+
+    def call
+      now = Time.current
+
+      rows = @user.availability_slots
+                  .where(category: @from_category)
+                  .pluck(:wday, :start_minute, :end_minute)
+                  .uniq
+                  .map do |wday, s, e|
+                    {
+                      user_id: @user.id,
+                      category: @to_category,
+                      wday: wday,
+                      start_minute: s,
+                      end_minute: e,
+                      created_at: now,
+                      updated_at: now
+                    }
+                  end
+
+      deleted = 0
+
+      ActiveRecord::Base.transaction do
+        deleted = @user.availability_slots.where(category: @to_category).delete_all
+        AvailabilitySlot.insert_all(rows) if rows.any?
+      end
+
+      { deleted: deleted, created: rows.size }
+    end
+  end
+end


### PR DESCRIPTION
Closes #87

## 概要
`AvailabilitySlot.overwrite_copy_category!` クラスメソッドをサービス層に移動しました。

## 変更内容

### 新規作成: `Availability::OverwriteCopyCategory` サービス
- モデルのクラスメソッドをサービスオブジェクトに変換
- トランザクション処理を含むビジネスロジックを抽出

### 削除: `AvailabilitySlot.overwrite_copy_category!`
- 28行のクラスメソッドを削除
- モデルをシンプルに保つ

### 修正: `AvailabilitySlotsController`
```ruby
# Before
result = AvailabilitySlot.overwrite_copy_category!(...)

# After
result = Availability::OverwriteCopyCategory.call(...)
```

## なぜこの変更が必要か

**Fat Modelアンチパターン**:
- モデルに複雑なビジネスロジック（28行）が含まれていた
- 単一責任の原則（SRP）に違反

**適切なレイヤー分離**:
- モデル: データ構造、バリデーション、単純なクエリ
- サービス: 複雑なビジネスロジック、複数モデルの操作

**テスタビリティ**:
- サービスオブジェクトは単独でテストしやすい
- モックやスタブを使いやすい

## 動作確認
- ✅ RuboCop通過
- ✅ ロジックは変更なし（完全に同じ動作）