### PR TITLE
全サービスのRSpecテストを実装

### DIFF
--- a/spec/services/availability/aggregate_counts_spec.rb
+++ b/spec/services/availability/aggregate_counts_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe Availability::AggregateCounts do
+  let(:user1) { create(:user, cohort: 1) }
+  let(:user2) { create(:user, cohort: 1) }
+  let(:user3) { create(:user, cohort: 2) }
+  let(:category) { "tech" }
+
+  describe '.call' do
+    context '基本的な集計' do
+      before do
+        # user1: 月曜 09:00-10:00
+        create(:availability_slot, user: user1, category: category, wday: 1, start_minute: 540, end_minute: 600)
+        # user2: 月曜 09:30-10:30
+        create(:availability_slot, user: user2, category: category, wday: 1, start_minute: 570, end_minute: 630)
+      end
+
+      it '30分ごとの参加可能人数を集計する' do
+        result = described_class.call(cohort: "all", category: category)
+
+        # 月曜 09:00-09:30: user1のみ
+        expect(result[1][18]).to eq(1)  # wday=1, index=18 (09:00)
+        # 月曜 09:30-10:00: user1 + user2
+        expect(result[1][19]).to eq(2)  # wday=1, index=19 (09:30)
+        # 月曜 10:00-10:30: user2のみ
+        expect(result[1][20]).to eq(1)  # wday=1, index=20 (10:00)
+      end
+    end
+
+    context 'cohortフィルター' do
+      before do
+        create(:availability_slot, user: user1, category: category, wday: 1, start_minute: 540, end_minute: 600)
+        create(:availability_slot, user: user2, category: category, wday: 1, start_minute: 540, end_minute: 600)
+        create(:availability_slot, user: user3, category: category, wday: 1, start_minute: 540, end_minute: 600)
+      end
+
+      it 'cohort指定で特定期生のみ集計する' do
+        result = described_class.call(cohort: "1", category: category)
+
+        expect(result[1][18]).to eq(2)  # cohort 1のみ（user1, user2）
+      end
+
+      it '"all"を指定すると全員を集計する' do
+        result = described_class.call(cohort: "all", category: category)
+
+        expect(result[1][18]).to eq(3)  # 全員（user1, user2, user3）
+      end
+    end
+
+    context 'categoryフィルター' do
+      before do
+        create(:availability_slot, user: user1, category: "tech", wday: 1, start_minute: 540, end_minute: 600)
+        create(:availability_slot, user: user1, category: "community", wday: 1, start_minute: 540, end_minute: 600)
+      end
+
+      it '指定されたカテゴリのみ集計される' do
+        result_tech = described_class.call(cohort: "all", category: "tech")
+        result_community = described_class.call(cohort: "all", category: "community")
+
+        expect(result_tech[1][18]).to eq(1)
+        expect(result_community[1][18]).to eq(1)
+      end
+    end
+
+    context '複数の曜日' do
+      before do
+        create(:availability_slot, user: user1, category: category, wday: 1, start_minute: 540, end_minute: 600)  # 月曜
+        create(:availability_slot, user: user1, category: category, wday: 3, start_minute: 540, end_minute: 600)  # 水曜
+      end
+
+      it '各曜日ごとに集計される' do
+        result = described_class.call(cohort: "all", category: category)
+
+        expect(result[1][18]).to eq(1)  # 月曜
+        expect(result[3][18]).to eq(1)  # 水曜
+        expect(result[2][18]).to eq(0)  # 火曜（登録なし）
+      end
+    end
+
+    context '返り値の構造' do
+      it '曜日0-6、時間帯0-47の2次元配列を返す' do
+        result = described_class.call(cohort: "all", category: "tech")
+
+        # 7日分の配列
+        expect(result.size).to eq(7)
+
+        # 各曜日に48時間帯分
+        result.each do |time_slots|
+          expect(time_slots.size).to eq(48)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/availability/bulk_create_slots_spec.rb
+++ b/spec/services/availability/bulk_create_slots_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe Availability::BulkCreateSlots do
+  let(:user) { create(:user) }
+  let(:category) { "tech" }
+
+  describe '.validate_inputs' do
+    it '曜日が空の場合はエラーを返す' do
+      error = described_class.validate_inputs(wdays: [], start_minute: 540, end_minute: 600)
+      expect(error).to eq("曜日を選択してください")
+    end
+
+    it '開始時刻または終了時刻が空の場合はエラーを返す' do
+      error = described_class.validate_inputs(wdays: [ 1, 2 ], start_minute: nil, end_minute: 600)
+      expect(error).to eq("開始時刻/終了時刻を選択してください")
+    end
+
+    it '終了時刻が空の場合もエラーを返す' do
+      error = described_class.validate_inputs(wdays: [ 1, 2 ], start_minute: 540, end_minute: nil)
+      expect(error).to eq("開始時刻/終了時刻を選択してください")
+    end
+
+    it '開始時刻が終了時刻以降の場合はエラーを返す' do
+      error = described_class.validate_inputs(wdays: [ 1, 2 ], start_minute: 600, end_minute: 540)
+      expect(error).to eq("開始時刻は終了時刻より前にしてください")
+    end
+
+    it 'すべて正常な場合はnilを返す' do
+      error = described_class.validate_inputs(wdays: [ 1, 2 ], start_minute: 540, end_minute: 600)
+      expect(error).to be_nil
+    end
+  end
+
+  describe '.call' do
+    context '新規スロットの追加' do
+      it '指定した曜日にスロットを追加する' do
+        result = described_class.call(
+          user: user,
+          category: category,
+          wdays: [ 1, 2 ],  # 月曜・火曜
+          start_minute: 540,  # 09:00
+          end_minute: 600     # 10:00
+        )
+
+        expect(result[:created]).to eq(2)
+        expect(user.availability_slots.where(wday: 1, category: category).count).to eq(1)
+        expect(user.availability_slots.where(wday: 2, category: category).count).to eq(1)
+      end
+    end
+
+    context '既存スロットとマージされる場合' do
+      before do
+        # 月曜 09:00-10:00 を事前登録
+        create(:availability_slot, user: user, category: category, wday: 1, start_minute: 540, end_minute: 600)
+      end
+
+      it '重複する時間帯は統合される' do
+        result = described_class.call(
+          user: user,
+          category: category,
+          wdays: [ 1, 2 ],
+          start_minute: 570,  # 09:30
+          end_minute: 630     # 10:30（既存と重複）
+        )
+
+        # 月曜は統合、火曜は新規
+        expect(result[:merged]).to eq(1)
+        expect(result[:created]).to eq(1)
+      end
+    end
+
+    context '既存スロットに完全に含まれる場合' do
+      before do
+        # 月曜 09:00-11:00 を事前登録
+        create(:availability_slot, user: user, category: category, wday: 1, start_minute: 540, end_minute: 660)
+      end
+
+      it '変更なしとしてカウントされる' do
+        result = described_class.call(
+          user: user,
+          category: category,
+          wdays: [ 1 ],
+          start_minute: 570,  # 09:30
+          end_minute: 630     # 10:30（既存に完全に含まれる）
+        )
+
+        expect(result[:unchanged]).to eq(1)
+        expect(result[:unchanged_wdays]).to include(1)
+      end
+    end
+  end
+end

--- a/spec/services/availability/bulk_update_slots_spec.rb
+++ b/spec/services/availability/bulk_update_slots_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.describe Availability::BulkUpdateSlots do
+  let(:user) { create(:user) }
+  let(:category) { "tech" }
+
+  describe '.call' do
+    context '既存スロットの更新' do
+      let!(:slot) { create(:availability_slot, user: user, category: category, wday: 1, start_minute: 540, end_minute: 600) }
+
+      it '既存スロットの時間を更新する' do
+        slots_param = {
+          slot.id.to_s => {
+            start_time: "10:00",
+            end_time: "11:00"
+          }
+        }
+
+        described_class.call(user: user, category: category, slots_param: slots_param)
+
+        slot.reload
+        expect(slot.start_minute).to eq(600)  # 10:00
+        expect(slot.end_minute).to eq(660)    # 11:00
+      end
+
+      it '文字列キーでも動作する' do
+        slots_param = {
+          slot.id.to_s => {
+            "start_time" => "10:00",
+            "end_time" => "11:00"
+          }
+        }
+
+        described_class.call(user: user, category: category, slots_param: slots_param)
+
+        slot.reload
+        expect(slot.start_minute).to eq(600)
+      end
+    end
+
+    context '新規スロットの作成' do
+      it 'new_で始まるキーは新規作成として扱う' do
+        slots_param = {
+          "new_1" => {
+            wday: 1,
+            category: category,
+            start_time: "09:00",
+            end_time: "10:00"
+          }
+        }
+
+        expect {
+          described_class.call(user: user, category: category, slots_param: slots_param)
+        }.to change { user.availability_slots.count }.by(1)
+
+        new_slot = user.availability_slots.last
+        expect(new_slot.wday).to eq(1)
+        expect(new_slot.start_minute).to eq(540)
+      end
+
+      it '開始時刻が終了時刻以降の場合はスキップする' do
+        slots_param = {
+          "new_1" => {
+            wday: 1,
+            category: category,
+            start_time: "10:00",
+            end_time: "09:00"  # 不正
+          }
+        }
+
+        expect {
+          described_class.call(user: user, category: category, slots_param: slots_param)
+        }.not_to change { user.availability_slots.count }
+      end
+
+      it '時刻がnilの場合はスキップする' do
+        slots_param = {
+          "new_1" => {
+            wday: 1,
+            category: category,
+            start_time: nil,
+            end_time: "10:00"
+          }
+        }
+
+        expect {
+          described_class.call(user: user, category: category, slots_param: slots_param)
+        }.not_to change { user.availability_slots.count }
+      end
+    end
+
+    context 'WeeklySlotNormalizerの呼び出し' do
+      it '更新後にWeeklySlotNormalizerが呼ばれる' do
+        allow(Availability::WeeklySlotNormalizer).to receive(:call)
+
+        described_class.call(user: user, category: category, slots_param: {})
+
+        expect(Availability::WeeklySlotNormalizer).to have_received(:call).with(user: user, category: category)
+      end
+    end
+
+    context 'トランザクション' do
+      let!(:slot) { create(:availability_slot, user: user, category: category, wday: 1, start_minute: 540, end_minute: 600) }
+
+      it 'エラーが発生した場合はロールバックされる' do
+        slots_param = {
+          slot.id.to_s => {
+            start_time: nil,  # 不正な値
+            end_time: "10:00"
+          }
+        }
+
+        expect {
+          described_class.call(user: user, category: category, slots_param: slots_param)
+        }.to raise_error(ActiveRecord::RecordInvalid)
+
+        slot.reload
+        expect(slot.start_minute).to eq(540)  # 変更されていない
+      end
+    end
+  end
+end

--- a/spec/services/availability/overwrite_copy_category_spec.rb
+++ b/spec/services/availability/overwrite_copy_category_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe Availability::OverwriteCopyCategory do
+  let(:user) { create(:user) }
+  let(:from_category) { "tech" }
+  let(:to_category) { "community" }
+
+  describe '.call' do
+    context '基本的なコピー' do
+      before do
+        create(:availability_slot, user: user, category: from_category, wday: 1, start_minute: 540, end_minute: 600)
+        create(:availability_slot, user: user, category: from_category, wday: 2, start_minute: 720, end_minute: 780)
+      end
+
+      it 'コピー元のスロットをコピー先に複製する' do
+        result = described_class.call(user: user, from_category: from_category, to_category: to_category)
+
+        expect(result[:created]).to eq(2)
+        expect(user.availability_slots.where(category: to_category).count).to eq(2)
+
+        copied_slots = user.availability_slots.where(category: to_category).order(:wday, :start_minute)
+        expect(copied_slots.first.wday).to eq(1)
+        expect(copied_slots.first.start_minute).to eq(540)
+        expect(copied_slots.last.wday).to eq(2)
+      end
+
+      it 'コピー元のスロットは削除されない' do
+        described_class.call(user: user, from_category: from_category, to_category: to_category)
+
+        expect(user.availability_slots.where(category: from_category).count).to eq(2)
+      end
+    end
+
+    context 'コピー先に既存スロットがある場合' do
+      before do
+        # コピー元
+        create(:availability_slot, user: user, category: from_category, wday: 1, start_minute: 540, end_minute: 600)
+        # コピー先（上書きされる）
+        create(:availability_slot, user: user, category: to_category, wday: 2, start_minute: 720, end_minute: 780)
+      end
+
+      it '既存スロットを削除してからコピーする' do
+        result = described_class.call(user: user, from_category: from_category, to_category: to_category)
+
+        expect(result[:deleted]).to eq(1)
+        expect(result[:created]).to eq(1)
+
+        # コピー先は上書きされている
+        expect(user.availability_slots.where(category: to_category).count).to eq(1)
+        expect(user.availability_slots.where(category: to_category).first.wday).to eq(1)
+      end
+    end
+
+    context '重複するスロットがある場合' do
+      before do
+        # コピー元に異なる時間帯で2つ作成（DBのユニーク制約により同じスロットは作成できない）
+        create(:availability_slot, user: user, category: from_category, wday: 1, start_minute: 540, end_minute: 600)
+        create(:availability_slot, user: user, category: from_category, wday: 1, start_minute: 600, end_minute: 660)
+      end
+
+      it '複数のスロットをコピーする' do
+        result = described_class.call(user: user, from_category: from_category, to_category: to_category)
+
+        expect(result[:created]).to eq(2)
+        expect(user.availability_slots.where(category: to_category).count).to eq(2)
+      end
+    end
+
+    context 'トランザクション' do
+      before do
+        create(:availability_slot, user: user, category: from_category, wday: 1, start_minute: 540, end_minute: 600)
+        create(:availability_slot, user: user, category: to_category, wday: 2, start_minute: 720, end_minute: 780)
+      end
+
+      it '削除とコピーが1つのトランザクションで実行される' do
+        allow(AvailabilitySlot).to receive(:insert_all).and_raise(ActiveRecord::StatementInvalid)
+
+        expect {
+          described_class.call(user: user, from_category: from_category, to_category: to_category)
+        }.to raise_error(ActiveRecord::StatementInvalid)
+
+        # ロールバックされて、コピー先の既存スロットは削除されていない
+        expect(user.availability_slots.where(category: to_category).count).to eq(1)
+      end
+    end
+
+    context 'コピー元が空の場合' do
+      before do
+        # コピー先に既存スロット
+        create(:availability_slot, user: user, category: to_category, wday: 2, start_minute: 720, end_minute: 780)
+      end
+
+      it 'コピー先を削除するだけ' do
+        result = described_class.call(user: user, from_category: from_category, to_category: to_category)
+
+        expect(result[:deleted]).to eq(1)
+        expect(result[:created]).to eq(0)
+        expect(user.availability_slots.where(category: to_category).count).to eq(0)
+      end
+    end
+
+    context '他のユーザーに影響しない' do
+      let(:other_user) { create(:user) }
+
+      before do
+        create(:availability_slot, user: user, category: from_category, wday: 1, start_minute: 540, end_minute: 600)
+        create(:availability_slot, user: other_user, category: to_category, wday: 2, start_minute: 720, end_minute: 780)
+      end
+
+      it '指定されたユーザーのみ処理される' do
+        described_class.call(user: user, from_category: from_category, to_category: to_category)
+
+        # other_userのスロットは変更されない
+        expect(other_user.availability_slots.count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/services/availability/range_merger_spec.rb
+++ b/spec/services/availability/range_merger_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe Availability::RangeMerger do
+  describe '.call' do
+    context '範囲が重複している場合' do
+      it '重複する範囲をマージする' do
+        ranges = [
+          { start_minute: 60, end_minute: 120, ids: [ 1 ] },   # 01:00-02:00
+          { start_minute: 90, end_minute: 150, ids: [ 2 ] }    # 01:30-02:30
+        ]
+        result = described_class.call(ranges)
+
+        expect(result).to eq([ { start_minute: 60, end_minute: 150, ids: [ 1, 2 ] } ])
+      end
+
+      it '完全に含まれる範囲を統合する' do
+        ranges = [
+          { start_minute: 60, end_minute: 180, ids: [ 1 ] },   # 01:00-03:00
+          { start_minute: 90, end_minute: 120, ids: [ 2 ] }    # 01:30-02:00（完全に内側）
+        ]
+        result = described_class.call(ranges)
+
+        expect(result).to eq([ { start_minute: 60, end_minute: 180, ids: [ 1, 2 ] } ])
+      end
+    end
+
+    context '範囲が重複していない場合' do
+      it '複数の独立した範囲をそのまま返す' do
+        ranges = [
+          { start_minute: 60, end_minute: 120, ids: [ 1 ] },   # 01:00-02:00
+          { start_minute: 180, end_minute: 240, ids: [ 2 ] }   # 03:00-04:00
+        ]
+        result = described_class.call(ranges)
+
+        expect(result.size).to eq(2)
+        expect(result).to include({ start_minute: 60, end_minute: 120, ids: [ 1 ] })
+        expect(result).to include({ start_minute: 180, end_minute: 240, ids: [ 2 ] })
+      end
+    end
+
+    context '空の配列の場合' do
+      it '空の配列を返す' do
+        expect(described_class.call([])).to eq([])
+      end
+    end
+
+    context '単一の範囲の場合' do
+      it 'そのまま返す' do
+        ranges = [ { start_minute: 60, end_minute: 120, ids: [ 1 ] } ]
+        result = described_class.call(ranges)
+
+        expect(result).to eq([ { start_minute: 60, end_minute: 120, ids: [ 1 ] } ])
+      end
+    end
+
+    context '複数の範囲が連続してマージされる場合' do
+      it '3つの範囲を1つにマージする' do
+        ranges = [
+          { start_minute: 60, end_minute: 90, ids: [ 1 ] },    # 01:00-01:30
+          { start_minute: 80, end_minute: 120, ids: [ 2 ] },   # 01:20-02:00
+          { start_minute: 110, end_minute: 150, ids: [ 3 ] }   # 01:50-02:30
+        ]
+        result = described_class.call(ranges)
+
+        expect(result).to eq([ { start_minute: 60, end_minute: 150, ids: [ 1, 2, 3 ] } ])
+      end
+    end
+
+    context 'ids未指定の場合' do
+      it '空配列として扱われる' do
+        ranges = [
+          { start_minute: 60, end_minute: 120 }
+        ]
+        result = described_class.call(ranges)
+
+        expect(result).to eq([ { start_minute: 60, end_minute: 120, ids: [] } ])
+      end
+    end
+  end
+end

--- a/spec/services/availability/time_converter_spec.rb
+++ b/spec/services/availability/time_converter_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe Availability::TimeConverter do
+  describe '.time_to_minutes' do
+    context '正常な時刻文字列の場合' do
+      it '"09:00"を分に変換する' do
+        expect(described_class.time_to_minutes("09:00")).to eq(540)
+      end
+
+      it '"12:30"を分に変換する' do
+        expect(described_class.time_to_minutes("12:30")).to eq(750)
+      end
+
+      it '"00:00"を分に変換する' do
+        expect(described_class.time_to_minutes("00:00")).to eq(0)
+      end
+
+      it '"23:59"を分に変換する' do
+        expect(described_class.time_to_minutes("23:59")).to eq(1439)
+      end
+
+      it '1桁の時間"9:30"を変換する' do
+        expect(described_class.time_to_minutes("9:30")).to eq(570)
+      end
+    end
+
+    context 'nilや空文字列の場合' do
+      it 'nilを渡すとnilを返す' do
+        expect(described_class.time_to_minutes(nil)).to be_nil
+      end
+
+      it '空文字列を渡すとnilを返す' do
+        expect(described_class.time_to_minutes("")).to be_nil
+      end
+    end
+
+    context '整数の場合' do
+      it '整数をそのまま返す' do
+        expect(described_class.time_to_minutes(540)).to eq(540)
+      end
+    end
+
+    context '不正な形式の場合' do
+      it '時刻以外の文字列はnilを返す' do
+        expect(described_class.time_to_minutes("invalid")).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/availability/weekly_slot_normalizer_spec.rb
+++ b/spec/services/availability/weekly_slot_normalizer_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe Availability::WeeklySlotNormalizer do
+  let(:user) { create(:user) }
+  let(:category) { "tech" }
+
+  describe '.call' do
+    context '重複する時間枠がある場合' do
+      before do
+        # 月曜に重複する2つのスロット
+        create(:availability_slot, user: user, category: category, wday: 1, start_minute: 540, end_minute: 600)   # 09:00-10:00
+        create(:availability_slot, user: user, category: category, wday: 1, start_minute: 570, end_minute: 630)   # 09:30-10:30
+      end
+
+      it '重複するスロットを1つにマージする' do
+        described_class.call(user: user, category: category)
+
+        slots = user.availability_slots.where(wday: 1, category: category).order(:start_minute)
+        expect(slots.count).to eq(1)
+        expect(slots.first.start_minute).to eq(540)
+        expect(slots.first.end_minute).to eq(630)
+      end
+    end
+
+    context '曜日ごとに独立して処理される場合' do
+      before do
+        # 月曜に重複スロット
+        create(:availability_slot, user: user, category: category, wday: 1, start_minute: 540, end_minute: 600)
+        create(:availability_slot, user: user, category: category, wday: 1, start_minute: 570, end_minute: 630)
+        # 火曜に重複スロット
+        create(:availability_slot, user: user, category: category, wday: 2, start_minute: 540, end_minute: 600)
+        create(:availability_slot, user: user, category: category, wday: 2, start_minute: 570, end_minute: 630)
+      end
+
+      it '各曜日ごとにマージされる' do
+        described_class.call(user: user, category: category)
+
+        monday_slots = user.availability_slots.where(wday: 1, category: category)
+        tuesday_slots = user.availability_slots.where(wday: 2, category: category)
+
+        expect(monday_slots.count).to eq(1)
+        expect(tuesday_slots.count).to eq(1)
+      end
+    end
+
+    context '重複しない時間枠の場合' do
+      before do
+        create(:availability_slot, user: user, category: category, wday: 1, start_minute: 540, end_minute: 600)   # 09:00-10:00
+        create(:availability_slot, user: user, category: category, wday: 1, start_minute: 720, end_minute: 780)   # 12:00-13:00
+      end
+
+      it 'スロット数は変わらない' do
+        expect {
+          described_class.call(user: user, category: category)
+        }.not_to change { user.availability_slots.where(wday: 1, category: category).count }
+      end
+    end
+
+    context 'スロットがない場合' do
+      it 'エラーなく処理される' do
+        expect {
+          described_class.call(user: user, category: category)
+        }.not_to raise_error
+      end
+    end
+
+    context '他のユーザーやカテゴリに影響しない' do
+      let(:other_user) { create(:user) }
+
+      before do
+        # 対象ユーザーの対象カテゴリ
+        create(:availability_slot, user: user, category: category, wday: 1, start_minute: 540, end_minute: 600)
+        create(:availability_slot, user: user, category: category, wday: 1, start_minute: 570, end_minute: 630)
+        # 他のユーザー
+        create(:availability_slot, user: other_user, category: category, wday: 1, start_minute: 540, end_minute: 600)
+        # 他のカテゴリ
+        create(:availability_slot, user: user, category: "community", wday: 1, start_minute: 540, end_minute: 600)
+      end
+
+      it '指定されたユーザーとカテゴリのみ処理される' do
+        described_class.call(user: user, category: category)
+
+        expect(user.availability_slots.where(category: category).count).to eq(1)  # マージされた
+        expect(other_user.availability_slots.count).to eq(1)  # 変更なし
+        expect(user.availability_slots.where(category: "community").count).to eq(1)  # 変更なし
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #89

## 概要
7つのサービスクラスの包括的なRSpecテストを実装しました。

## 新規作成テストファイル

| ファイル | テスト数 | カバレッジ内容 |
|----------|----------|---------------|
| `time_converter_spec.rb` | 9 examples | 時刻文字列→分変換の全パターン |
| `range_merger_spec.rb` | 7 examples | 時間範囲マージの全パターン |
| `bulk_create_slots_spec.rb` | 8 examples | 一括スロット作成のバリデーション・統合 |
| `bulk_update_slots_spec.rb` | 7 examples | 一括更新・トランザクション |
| `weekly_slot_normalizer_spec.rb` | 5 examples | 重複スロット統合ロジック |
| `aggregate_counts_spec.rb` | 7 examples | 参加可能人数集計・フィルター |
| `overwrite_copy_category_spec.rb` | 6 examples | カテゴリ間コピー・トランザクション |

**合計**: 49 examples, 0 failures

## テスト内容

### 正常系
- 各サービスの主要機能が正しく動作
- 期待値通りの結果を返す

### 異常系
- バリデーションエラーの適切な処理
- nil/空文字列の処理
- 不正な入力値への対応

### エッジケース
- 境界値テスト
- 重複データの処理
- トランザクションのロールバック

### 依存関係
- 他サービスの呼び出し検証（モック使用）
- ユーザー・カテゴリごとの分離

## なぜこの変更が必要か

**サービス層の複雑化**:
- 7つのサービスクラスが複雑なビジネスロジックを持つ
- テストなしでは変更時の影響範囲が不明

**品質保証**:
- リファクタリング時の安全性確保
- 回帰テストによるデグレ防止
- 仕様の明文化

## 動作確認
- ✅ RSpec: 49 examples, 0 failures
- ✅ RuboCop: no offenses detected