### PR TITLE
[リファクタ] cohort_optionsクエリの重複解消

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,7 @@ class HomeController < ApplicationController
     @category = "tech" unless Theme::CATEGORY_KEYS.include?(@category)
 
     # セレクト用（存在する期だけ出す）
-    @cohort_options = User.distinct.order(:cohort).pluck(:cohort).compact
+    @cohort_options = User.cohort_options
 
     # 集計（共通基盤を呼ぶ）
     @availability_counts = Availability::AggregateCounts.call(

--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -61,7 +61,7 @@ class ThemesController < ApplicationController
 
     return unless @availability_supported
 
-    @cohort_options = User.distinct.order(:cohort).pluck(:cohort).compact
+    @cohort_options = User.cohort_options
 
     @availability_counts = Availability::AggregateCounts.call(
       cohort: @cohort,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,8 @@ class User < ApplicationRecord
   def cohort_label
     cohort.to_i > 0 ? "#{cohort}期" : "未設定"
   end
+
+  def self.cohort_options
+    distinct.order(:cohort).pluck(:cohort).compact
+  end
 end


### PR DESCRIPTION
## 概要
HomeControllerとThemesControllerで同一のcohort_optionsクエリが重複していたため、Userモデルのクラスメソッドに抽出しました。

Fixes #109

## 変更内容
- `User.cohort_options` クラスメソッドを追加
- HomeController#index で重複クエリを削除
- ThemesController#prepare_availability_aggregate で重複クエリを削除

### Before
```ruby
# HomeController
@cohort_options = User.distinct.order(:cohort).pluck(:cohort).compact

# ThemesController
@cohort_options = User.distinct.order(:cohort).pluck(:cohort).compact
```

### After
```ruby
# User model
def self.cohort_options
  distinct.order(:cohort).pluck(:cohort).compact
end

# Both controllers
@cohort_options = User.cohort_options
```

## メリット
- DRY原則に従い、重複を排除
- クエリロジックが一箇所に集約され、変更が容易
- Userモデルの責務として適切に配置

## テスト
- 既存のテストスイートが通ることを確認済み