### PR TITLE
[リファクタ] Userモデルにバリデーション追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  validates :nickname, presence: true, length: { maximum: 50 }
+  validates :cohort, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+
   has_many :themes, dependent: :destroy
   has_many :theme_votes, dependent: :destroy
   has_many :voted_themes, through: :theme_votes, source: :theme


### PR DESCRIPTION
## 概要
Userモデルのnicknameおよびcohortカラムにバリデーションが設定されていなかったため、データ整合性を保証するバリデーションを追加しました。

Fixes #110

## 変更内容
- `nickname`: presence（必須）、length（最大50文字）
- `cohort`: numericality（正の整数のみ）、allow_nil（未設定を許可）

```ruby
validates :nickname, presence: true, length: { maximum: 50 }
validates :cohort, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
```

## メリット
- 不正なデータの登録を防止
- データベースレベルの整合性を担保
- ユーザーに適切なエラーメッセージを表示

## テスト
- 既存のテストスイートが通ることを確認済み