### PR TITLE
[リファクタ] Themeモデルにスコープ・バリデーション追加

### DIFF
--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -3,7 +3,7 @@ class ThemesController < ApplicationController
   before_action :set_theme, only: %i[show destroy]
 
   def index
-    @themes = Theme.order(created_at: :desc).page(params[:page]).per(20)
+    @themes = Theme.recent.page(params[:page]).per(20)
   end
 
   def show

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -7,9 +7,13 @@ class Theme < ApplicationRecord
   enum :category, { tech: 0, community: 1 }
 
   validates :category, presence: true
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: 100 }
   validates :description, presence: true, length: { maximum: 1000 }
   validates :secondary_label, presence: true, if: :secondary_enabled?
+
+  scope :recent, -> { order(created_at: :desc) }
+  scope :by_category, ->(category) { where(category: category) }
+  scope :popular, -> { order(theme_votes_count: :desc) }
 
   has_many :theme_votes, dependent: :destroy
   has_many :voters, through: :theme_votes, source: :user


### PR DESCRIPTION
## 概要
Themeモデルにスコープとバリデーションを追加して、コードの可読性と保守性を向上させました。

Fixes #111

## 変更内容

### バリデーション
- `title`: length（最大100文字）を追加

### スコープ
- `recent`: created_at の降順で取得
- `by_category(category)`: 指定カテゴリで絞り込み
- `popular`: theme_votes_count の降順で取得

### 使用例
```ruby
# Before
Theme.order(created_at: :desc)

# After
Theme.recent
```

## メリット
- クエリが意図明確で読みやすい
- スコープのチェーンで複雑な条件も簡潔に記述可能
- `Theme.recent.by_category('tech').popular` のような組み合わせが可能

## テスト
- 既存のテストスイートが通ることを確認済み
- ThemesController#index で recent スコープが正常に動作