### PR TITLE
[feature] テーマの編集機能を追加

### DIFF
--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -1,6 +1,6 @@
 class ThemesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_theme, only: %i[show destroy]
+  before_action :set_theme, only: %i[show edit update destroy]
 
   def index
     @themes = Theme.recent.page(params[:page]).per(20)
@@ -28,6 +28,21 @@ class ThemesController < ApplicationController
     else
       flash.now[:alert] = "入力内容を確認してください"
       render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    authorize_owner!(@theme)
+  end
+
+  def update
+    authorize_owner!(@theme)
+
+    if @theme.update(theme_params)
+      redirect_to @theme, notice: "テーマを更新しました。", status: :see_other
+    else
+      flash.now[:alert] = "入力内容を確認してください"
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/views/themes/edit.html.erb
+++ b/app/views/themes/edit.html.erb
@@ -1,0 +1,18 @@
+<%= render_breadcrumbs([
+  bc("ホーム", root_path),
+  bc("テーマ一覧", themes_path),
+  bc(@theme.title, theme_path(@theme)),
+  bc("編集")
+]) %>
+<div class="mx-auto max-w-2xl">
+  <div class="card bg-base-100 shadow-lg ring-1 ring-base-300">
+    <div class="card-body">
+      <h1 class="card-title text-2xl font-bold">テーマを編集</h1>
+      <p class="text-sm text-base-content/60">投稿したテーマの内容を修正できます。</p>
+
+      <div class="divider"></div>
+
+      <%= render "form", theme: @theme %>
+    </div>
+  </div>
+</div>

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -22,6 +22,7 @@
       <div class="flex flex-wrap items-start gap-2">
         <%= render "themes/vote_section", theme: @theme %>
         <% if user_signed_in? && current_user == @theme.user %>
+          <%= link_to "編集", edit_theme_path(@theme), class: "btn btn-ghost btn-sm" %>
           <%= button_to "削除", theme_path(@theme),
                         method: :delete,
                         data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   end
 end
 
-  resources :themes, only: %i[index show new create destroy] do
+  resources :themes, only: %i[index show new create edit update destroy] do
   scope module: :themes do
     resource  :vote,           only: %i[create destroy]
     resources :theme_comments, only: %i[create destroy]


### PR DESCRIPTION
## 概要
ユーザーが投稿したテーマを後から編集できる機能を追加しました。

Fixes #114

## 変更内容

### ルーティング
- themes に edit/update アクションを追加

### コントローラー
- `ThemesController#edit`: 編集フォーム表示
- `ThemesController#update`: 更新処理
- 両アクションで `authorize_owner!` による認可チェック

### ビュー
- `app/views/themes/edit.html.erb`: 編集ページ
- `app/views/themes/show.html.erb`: 所有者に「編集」ボタンを表示

## 使用方法
1. 自分が投稿したテーマの詳細ページを開く
2. 「編集」ボタンをクリック
3. フォームで内容を修正
4. 「更新」ボタンで保存

## セキュリティ
- 編集・更新は所有者のみ可能（`authorize_owner!` で保護）
- 他ユーザーのテーマは編集不可

## テスト
- 既存のテストスイートが通ることを確認済み