### PR TITLE
投票トグル機能のテスト追加とテスト環境の改善

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,9 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  allow_browser versions: :modern unless Rails.env.test?
 
   # Changes to the importmap will invalidate the etag for HTML responses
-  stale_when_importmap_changes
+  stale_when_importmap_changes unless Rails.env.test?
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 

--- a/spec/factories/theme_votes.rb
+++ b/spec/factories/theme_votes.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :theme_vote do
-    user { nil }
-    theme { nil }
+    association :user
+    association :theme
   end
 end

--- a/spec/models/theme_vote_spec.rb
+++ b/spec/models/theme_vote_spec.rb
@@ -1,5 +1,57 @@
 require 'rails_helper'
 
 RSpec.describe ThemeVote, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:theme).counter_cache(true) }
+  end
+
+  describe 'validations' do
+    subject { build(:theme_vote) }
+    it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:theme_id) }
+  end
+
+  describe 'database constraints' do
+    let(:user) { create(:user) }
+    let(:theme) { create(:theme) }
+
+    it 'has unique index on user_id and theme_id' do
+      create(:theme_vote, user: user, theme: theme)
+
+      # Directly insert bypassing ActiveRecord validations to test DB constraint
+      expect {
+        ActiveRecord::Base.connection.execute(
+          "INSERT INTO theme_votes (user_id, theme_id, created_at, updated_at)
+           VALUES (#{user.id}, #{theme.id}, NOW(), NOW())"
+        )
+      }.to raise_error(ActiveRecord::StatementInvalid, /duplicate key value violates unique constraint/)
+    end
+  end
+
+  describe 'counter_cache' do
+    let(:theme) { create(:theme) }
+    let(:user1) { create(:user) }
+    let(:user2) { create(:user) }
+
+    it 'increments theme_votes_count when created' do
+      expect {
+        create(:theme_vote, theme: theme, user: user1)
+      }.to change { theme.reload.theme_votes_count }.by(1)
+    end
+
+    it 'decrements theme_votes_count when destroyed' do
+      vote = create(:theme_vote, theme: theme, user: user1)
+
+      expect {
+        vote.destroy
+      }.to change { theme.reload.theme_votes_count }.by(-1)
+    end
+
+    it 'accurately counts multiple votes' do
+      create(:theme_vote, theme: theme, user: user1)
+      create(:theme_vote, theme: theme, user: user2)
+
+      expect(theme.reload.theme_votes_count).to eq(2)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 # Ensures that the test database schema matches the current schema file.
 # If there are pending migrations it will invoke `db:test:prepare` to

--- a/spec/requests/themes/votes_spec.rb
+++ b/spec/requests/themes/votes_spec.rb
@@ -1,0 +1,154 @@
+require 'rails_helper'
+
+RSpec.describe "Themes::Votes", type: :request do
+  let(:user) { create(:user) }
+  let(:theme) { create(:theme) }
+
+  describe "POST /themes/:theme_id/vote" do
+    context "when user is not signed in" do
+      it "redirects to sign in page" do
+        post theme_vote_path(theme)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when user is signed in" do
+      before { sign_in user }
+
+      context "when user has not voted yet" do
+        it "creates a new vote" do
+          expect {
+            post theme_vote_path(theme)
+          }.to change(ThemeVote, :count).by(1)
+        end
+
+        it "increments theme votes count" do
+          expect {
+            post theme_vote_path(theme)
+          }.to change { theme.reload.theme_votes_count }.by(1)
+        end
+
+        it "redirects to theme page with notice" do
+          post theme_vote_path(theme)
+          expect(response).to redirect_to(theme)
+          expect(flash[:notice]).to eq("投票しました")
+        end
+      end
+
+      context "when user has already voted" do
+        before { create(:theme_vote, user: user, theme: theme) }
+
+        it "does not create duplicate vote" do
+          expect {
+            post theme_vote_path(theme)
+          }.not_to change(ThemeVote, :count)
+        end
+
+        it "redirects with already voted notice" do
+          post theme_vote_path(theme)
+          expect(response).to redirect_to(theme)
+          expect(flash[:notice]).to eq("既に投票済みです")
+        end
+      end
+
+      context "when concurrent vote attempts occur" do
+        it "handles race condition gracefully" do
+          create(:theme_vote, user: user, theme: theme)
+
+          expect {
+            post theme_vote_path(theme)
+          }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  describe "DELETE /themes/:theme_id/vote" do
+    context "when user is not signed in" do
+      it "redirects to sign in page" do
+        delete theme_vote_path(theme)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when user is signed in" do
+      before { sign_in user }
+
+      context "when user has voted" do
+        let!(:vote) { create(:theme_vote, user: user, theme: theme) }
+
+        it "destroys the vote" do
+          expect {
+            delete theme_vote_path(theme)
+          }.to change(ThemeVote, :count).by(-1)
+        end
+
+        it "decrements theme votes count" do
+          expect {
+            delete theme_vote_path(theme)
+          }.to change { theme.reload.theme_votes_count }.by(-1)
+        end
+
+        it "redirects to theme page with notice" do
+          delete theme_vote_path(theme)
+          expect(response).to redirect_to(theme)
+          expect(flash[:notice]).to eq("投票を取り消しました")
+        end
+      end
+
+      context "when user has not voted" do
+        it "does not raise error" do
+          expect {
+            delete theme_vote_path(theme)
+          }.not_to change(ThemeVote, :count)
+        end
+
+        it "redirects with already cancelled notice" do
+          delete theme_vote_path(theme)
+          expect(response).to redirect_to(theme)
+          expect(flash[:notice]).to eq("既に取り消し済みです")
+        end
+      end
+
+      context "when vote was already deleted" do
+        it "handles double deletion gracefully" do
+          expect {
+            delete theme_vote_path(theme)
+            delete theme_vote_path(theme)
+          }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  describe "vote toggle behavior" do
+    before { sign_in user }
+
+    it "allows user to vote, unvote, and revote" do
+      # 投票
+      post theme_vote_path(theme)
+      expect(theme.reload.theme_votes_count).to eq(1)
+
+      # 取消
+      delete theme_vote_path(theme)
+      expect(theme.reload.theme_votes_count).to eq(0)
+
+      # 再投票
+      post theme_vote_path(theme)
+      expect(theme.reload.theme_votes_count).to eq(1)
+    end
+
+    it "maintains accurate count with multiple users" do
+      user2 = create(:user)
+
+      post theme_vote_path(theme)
+      sign_in user2
+      post theme_vote_path(theme)
+
+      expect(theme.reload.theme_votes_count).to eq(2)
+
+      delete theme_vote_path(theme)
+      expect(theme.reload.theme_votes_count).to eq(1)
+    end
+  end
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,8 @@
+RSpec.configure do |config|
+  config.include Devise::Test::IntegrationHelpers, type: :request
+
+  # allow_browserチェックをスキップするヘルパー
+  config.before(:each, type: :request) do
+    allow_any_instance_of(ApplicationController).to receive(:allow_browser).and_return(true)
+  end
+end


### PR DESCRIPTION
## 概要
Issue #17 で要求されている投票トグル機能は既に完全に実装済みでした。そのため、このPRでは包括的なテストカバレッジの追加と、テストインフラの改善を行いました。

## 変更内容

### 1. ThemeVote モデルスペック
- **アソシエーション**: user, theme (counter_cache付き)
- **バリデーション**: user_id の uniqueness (scope: theme_id)
- **DB制約**: unique index の動作確認
- **counter_cache**: 投票数の増減が正しく反映されることを検証

### 2. Votes Controller リクエストスペック
- **POST /themes/:theme_id/vote**
  - 未ログイン時のリダイレクト
  - 投票作成と投票数の増加
  - 重複投票の防止
  - 競合状態の適切な処理
- **DELETE /themes/:theme_id/vote**
  - 未ログイン時のリダイレクト
  - 投票削除と投票数の減少
  - 存在しない投票の削除の適切な処理
- **トグル動作**
  - 投票→取消→再投票のサイクル
  - 複数ユーザーでの投票数の正確性

### 3. テストインフラの改善
- **spec/support/devise.rb**: Devise::Test::IntegrationHelpers を有効化し、認証が必要なリクエストスペックをテスト可能に
- **spec/rails_helper.rb**: spec/support/ の自動読み込みを有効化
- **ApplicationController**: test環境で allow_browser と stale_when_importmap_changes を無効化（テスト実行時の403エラーを解消）
- **ThemeVote Factory**: nil アソシエーションを association ヘルパーに修正

## テスト結果
```bash
$ RAILS_ENV=test bundle exec rspec spec/models/theme_vote_spec.rb
7 examples, 0 failures

$ RAILS_ENV=test bundle exec rspec spec/requests/themes/votes_spec.rb
16 examples, 0 failures
```

## 既存実装の確認
投票機能は以下がすでに実装済みでした：
- ✅ ThemeVoteモデル: user_id + theme_id の一意性制約（DB & モデル）
- ✅ Votes Controller: create/destroy アクション
- ✅ ルーティング: resource :vote, only: %i[create destroy]
- ✅ ビュー: 投票状態に応じたボタン切り替え
- ✅ counter_cache: theme_votes_count の自動更新

## Closes
Closes #17