### PR TITLE
参加表明なしで第2ボタンを無効化

### DIFF
--- a/app/controllers/themes/rsvps_controller.rb
+++ b/app/controllers/themes/rsvps_controller.rb
@@ -4,8 +4,27 @@ module Themes
 
     def update
       @rsvp = current_user.rsvps.find_or_initialize_by(theme: @theme)
+      params_to_update = rsvp_params.to_h.symbolize_keys
 
-      updated = @rsvp.update(rsvp_params)
+      # status を先に assign して、attending? の判定ができるようにする
+      if params_to_update.key?(:status)
+        @rsvp.assign_attributes(status: params_to_update[:status])
+      end
+
+      # secondary_interest を更新しようとしている場合、参加表明が attending でなければ拒否
+      if params_to_update.key?(:secondary_interest) && !@rsvp.attending?
+        # secondary_interest のみの更新の場合はエラー
+        if params_to_update.keys.sort == [:secondary_interest]
+          @rsvp_counts = @theme.rsvp_counts
+          flash.now[:alert] = "参加表明が必要です。"
+          render :update, status: :unprocessable_entity
+          return
+        end
+        # status と同時更新の場合は、secondary_interest を無視
+        params_to_update.delete(:secondary_interest)
+      end
+
+      updated = @rsvp.update(params_to_update)
       @rsvp_counts = @theme.rsvp_counts
 
       message = updated ? "参加状態を更新しました。" : "更新に失敗しました。"

--- a/app/views/themes/_rsvp_section.html.erb
+++ b/app/views/themes/_rsvp_section.html.erb
@@ -30,12 +30,17 @@
     <% if theme.secondary_enabled? %>
       <% secondary_label = theme.secondary_label.presence || "第2ボタン" %>
       <% next_secondary = !secondary_on %>
+      <% can_use_secondary = current_status == 'attending' %>
       <div class="mt-4">
         <%= button_to "#{secondary_label}（#{secondary_on ? 'ON' : 'OFF'}）",
               theme_rsvp_path(theme), method: :patch,
               params: { rsvp: { secondary_interest: next_secondary } },
               class: "btn #{secondary_on ? 'btn-accent' : 'btn-outline btn-accent'}",
+              disabled: !can_use_secondary,
               form: { data: { turbo_stream: true } } %>
+        <% unless can_use_secondary %>
+          <p class="mt-1 text-xs text-base-content/60">※「参加」を選択すると押せるようになります</p>
+        <% end %>
       </div>
     <% end %>
   <% else %>

--- a/spec/requests/themes/rsvps_spec.rb
+++ b/spec/requests/themes/rsvps_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe "Themes::Rsvps", type: :request do
+  let(:user) { create(:user) }
+  let(:theme) { create(:theme, secondary_enabled: true, secondary_label: "第2希望") }
+
+  describe "PATCH /themes/:theme_id/rsvp" do
+    before { sign_in user }
+
+    # Turbo Stream形式でリクエストを送るヘルパー
+    def patch_rsvp(params)
+      patch theme_rsvp_path(theme), params: params, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    context "when updating status" do
+      it "creates rsvp and updates status" do
+        expect {
+          patch_rsvp({ rsvp: { status: :attending } })
+        }.to change(Rsvp, :count).by(1)
+
+        expect(Rsvp.last.status).to eq("attending")
+      end
+
+      it "updates existing rsvp status" do
+        rsvp = create(:rsvp, user: user, theme: theme, status: :undecided)
+
+        patch_rsvp({ rsvp: { status: :attending } })
+
+        expect(rsvp.reload.status).to eq("attending")
+      end
+    end
+
+    context "when updating secondary_interest" do
+      context "with attending status" do
+        let!(:rsvp) { create(:rsvp, user: user, theme: theme, status: :attending, secondary_interest: false) }
+
+        it "allows secondary_interest update" do
+          patch_rsvp({ rsvp: { secondary_interest: true } })
+
+          expect(rsvp.reload.secondary_interest).to be true
+        end
+
+        it "returns success response" do
+          patch_rsvp({ rsvp: { secondary_interest: true } })
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "without attending status (undecided)" do
+        let!(:rsvp) { create(:rsvp, user: user, theme: theme, status: :undecided, secondary_interest: false) }
+
+        it "rejects secondary_interest update" do
+          patch_rsvp({ rsvp: { secondary_interest: true } })
+
+          expect(rsvp.reload.secondary_interest).to be false
+        end
+
+        it "returns unprocessable_entity" do
+          patch_rsvp({ rsvp: { secondary_interest: true } })
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "shows error message" do
+          patch_rsvp({ rsvp: { secondary_interest: true } })
+
+          expect(flash[:alert]).to eq("参加表明が必要です。")
+        end
+      end
+
+      context "without attending status (not_attending)" do
+        let!(:rsvp) { create(:rsvp, user: user, theme: theme, status: :not_attending, secondary_interest: false) }
+
+        it "rejects secondary_interest update" do
+          patch_rsvp({ rsvp: { secondary_interest: true } })
+
+          expect(rsvp.reload.secondary_interest).to be false
+        end
+      end
+
+      context "when rsvp does not exist yet (new record)" do
+        it "rejects secondary_interest update" do
+          expect {
+            patch_rsvp({ rsvp: { secondary_interest: true } })
+          }.not_to change(Rsvp, :count)
+        end
+
+        it "returns unprocessable_entity" do
+          patch_rsvp({ rsvp: { secondary_interest: true } })
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    context "when updating both status and secondary_interest" do
+      it "allows updating both when status is attending" do
+        rsvp = create(:rsvp, user: user, theme: theme, status: :undecided, secondary_interest: false)
+
+        patch_rsvp({ rsvp: { status: :attending, secondary_interest: true } })
+
+        rsvp.reload
+        expect(rsvp.status).to eq("attending")
+        expect(rsvp.secondary_interest).to be true
+      end
+
+      it "rejects secondary_interest when status is not attending" do
+        rsvp = create(:rsvp, user: user, theme: theme, status: :attending, secondary_interest: true)
+
+        patch_rsvp({ rsvp: { status: :undecided, secondary_interest: true } })
+
+        rsvp.reload
+        expect(rsvp.status).to eq("undecided")
+        expect(rsvp.secondary_interest).to be true # 変更されない
+      end
+    end
+
+    context "when changing from attending to not_attending" do
+      let!(:rsvp) { create(:rsvp, user: user, theme: theme, status: :attending, secondary_interest: true) }
+
+      it "allows status change but keeps secondary_interest unchanged" do
+        patch_rsvp({ rsvp: { status: :not_attending } })
+
+        rsvp.reload
+        expect(rsvp.status).to eq("not_attending")
+        expect(rsvp.secondary_interest).to be true # そのまま
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Issue #18 の要件に従い、参加状態が「参加する（attending）」でない場合に、第2ボタン（secondary_interest）を押せないようにしました。UI側とサーバー側の両方で制御を追加し、直接APIを叩いても不正な操作ができないようにしました。

## 変更内容

### 1. UI側の制御
**ファイル**: `app/views/themes/_rsvp_section.html.erb`

- 第2ボタンに `disabled` 属性を追加
  - `current_status == 'attending'` でない場合は押せない
- 無効化時にヒントテキストを表示
  - 「※『参加』を選択すると押せるようになります」

### 2. サーバー側の制御
**ファイル**: `app/controllers/themes/rsvps_controller.rb`

#### ロジック
1. リクエストパラメータを取得
2. `status` パラメータがあれば先に `assign_attributes` で仮適用
3. `secondary_interest` パラメータがあり、かつ `@rsvp.attending?` が `false` の場合：
   - `secondary_interest` のみの更新 → **422エラーで拒否**
   - `status` と同時更新 → `secondary_interest` を無視して `status` のみ更新

#### 具体例
| リクエスト | 現在の状態 | 結果 |
|-----------|------------|------|
| `{ secondary_interest: true }` | undecided | ❌ 422エラー（参加表明が必要） |
| `{ status: :attending, secondary_interest: true }` | undecided | ✅ 両方更新される |
| `{ status: :undecided, secondary_interest: true }` | attending | ✅ status のみ更新、secondary_interest は無視 |

### 3. テストカバレッジ
**ファイル**: `spec/requests/themes/rsvps_spec.rb`

全13テストで以下をカバー：

#### テストケース
- ✅ status 更新（新規作成・既存更新）
- ✅ attending 状態での secondary_interest 更新（成功）
- ✅ undecided 状態での secondary_interest 更新（拒否）
- ✅ not_attending 状態での secondary_interest 更新（拒否）
- ✅ rsvp未作成での secondary_interest 更新（拒否）
- ✅ status と secondary_interest の同時更新（attending → 成功）
- ✅ status と secondary_interest の同時更新（non-attending → secondary_interest 無視）
- ✅ attending → not_attending 変更時の secondary_interest 保持

## テスト結果
```bash
$ RAILS_ENV=test bundle exec rspec spec/requests/themes/rsvps_spec.rb
13 examples, 0 failures
```

## セキュリティ
- UI無効化だけでなく、サーバー側でも検証
- 直接APIを叩いても不正な操作は拒否される

## Closes
Closes #18