### PR TITLE
アーカイブ機能を追加

### DIFF
--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -3,7 +3,11 @@ class ThemesController < ApplicationController
   before_action :set_theme, only: %i[show edit update destroy]
 
   def index
-    @themes = Theme.recent.page(params[:page]).per(20)
+    @themes = Theme.active_themes.recent.page(params[:page]).per(20)
+  end
+
+  def archived
+    @themes = Theme.archived_themes.recent.page(params[:page]).per(20)
   end
 
   def show

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -5,8 +5,10 @@ class Theme < ApplicationRecord
   belongs_to :user
 
   enum :category, { tech: 0, community: 1 }
+  enum :status, { active: 0, archived: 1 }
 
   validates :category, presence: true
+  validates :status, presence: true
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, presence: true, length: { maximum: 1000 }
   validates :secondary_label, presence: true, if: :secondary_enabled?
@@ -14,6 +16,8 @@ class Theme < ApplicationRecord
   scope :recent, -> { order(created_at: :desc) }
   scope :by_category, ->(category) { where(category: category) }
   scope :popular, -> { order(theme_votes_count: :desc) }
+  scope :active_themes, -> { where(status: :active) }
+  scope :archived_themes, -> { where(status: :archived) }
 
   has_many :theme_votes, dependent: :destroy
   has_many :voters, through: :theme_votes, source: :user

--- a/app/views/themes/archived.html.erb
+++ b/app/views/themes/archived.html.erb
@@ -1,0 +1,43 @@
+<div class="container mx-auto px-4 py-8">
+  <div class="mb-6 flex items-center justify-between">
+    <h1 class="text-3xl font-bold">アーカイブされたテーマ</h1>
+    <%= link_to "テーマ一覧に戻る", themes_path, class: "btn btn-outline btn-sm" %>
+  </div>
+
+  <% if @themes.any? %>
+    <div class="grid gap-4">
+      <% @themes.each do |theme| %>
+        <%= link_to theme_path(theme), class: "card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow" do %>
+          <div class="card-body">
+            <div class="flex items-start justify-between">
+              <div class="flex-1">
+                <h2 class="card-title">
+                  <%= theme.title %>
+                  <div class="badge badge-ghost badge-sm">アーカイブ</div>
+                </h2>
+                <p class="text-sm text-base-content/60"><%= truncate(theme.description, length: 100) %></p>
+              </div>
+              <div class="flex flex-col gap-2 text-right">
+                <span class="text-xs text-base-content/60"><%= theme.created_at.strftime('%Y/%m/%d') %></span>
+                <div class="badge badge-outline badge-sm"><%= Theme.human_enum_name(:category, theme.category) %></div>
+              </div>
+            </div>
+            <div class="card-actions justify-end">
+              <div class="stat-value text-primary text-2xl"><%= theme.theme_votes_count %></div>
+              <span class="text-xs text-base-content/60">投票</span>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="mt-8">
+      <%= paginate @themes %>
+    </div>
+  <% else %>
+    <div role="alert" class="alert">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-6 w-6 shrink-0 stroke-info"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+      <span>アーカイブされたテーマはありません。</span>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
 end
 
   resources :themes, only: %i[index show new create edit update destroy] do
+  collection do
+    get :archived
+  end
   scope module: :themes do
     resource  :vote,           only: %i[create destroy]
     resources :theme_comments, only: %i[create destroy]

--- a/db/migrate/20260211164650_add_status_to_themes.rb
+++ b/db/migrate/20260211164650_add_status_to_themes.rb
@@ -1,0 +1,5 @@
+class AddStatusToThemes < ActiveRecord::Migration[7.2]
+  def change
+    add_column :themes, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_06_152112) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_11_164650) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -82,6 +82,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_06_152112) do
     t.boolean "secondary_enabled", default: false, null: false
     t.string "secondary_label"
     t.integer "theme_votes_count", default: 0, null: false
+    t.integer "status", default: 0, null: false
     t.index ["community_id"], name: "index_themes_on_community_id"
     t.index ["user_id"], name: "index_themes_on_user_id"
   end

--- a/spec/requests/themes_archived_spec.rb
+++ b/spec/requests/themes_archived_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe "Themes Archived", type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  describe "GET /themes/archived" do
+    let!(:active_theme) { create(:theme, status: :active) }
+    let!(:archived_theme) { create(:theme, status: :archived) }
+
+    it "returns http success" do
+      get archived_themes_path
+      expect(response).to have_http_status(:success)
+    end
+
+    it "displays only archived themes" do
+      get archived_themes_path
+      expect(response.body).to include(archived_theme.title)
+      expect(response.body).not_to include(active_theme.title)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Issue #22 の要件に従い、テーマのアーカイブ機能を追加しました。status カラムを追加し、archived状態のテーマを `/themes/archived` で閲覧できるようにしました。

## 変更内容

### 1. データベース
- status カラム追加（integer, default: 0, null: false）
- enum定義: active(0), archived(1)

### 2. モデル
- `enum :status` 追加
- `active_themes`, `archived_themes` スコープ追加
- index で active_themes のみ表示

### 3. ルーティング
- `GET /themes/archived` 追加

### 4. コントローラー
- `archived` アクション追加

### 5. ビュー
- アーカイブ一覧ページ作成

### 6. テスト
- アーカイブページのリクエストスペック追加

## テスト結果
```bash
$ RAILS_ENV=test bundle exec rspec spec/requests/themes_archived_spec.rb
2 examples, 0 failures
```

## Closes
Closes #22