### PR TITLE
テーマ一覧に検索機能を追加

### DIFF
--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -3,7 +3,10 @@ class ThemesController < ApplicationController
   before_action :set_theme, only: %i[show edit update destroy]
 
   def index
-    @themes = Theme.active_themes.recent.page(params[:page]).per(20)
+    @themes = Theme.active_themes
+    @themes = @themes.search_by_keyword(params[:keyword]) if params[:keyword].present?
+    @themes = @themes.by_category(params[:category]) if params[:category].present?
+    @themes = @themes.recent.page(params[:page]).per(20)
   end
 
   def archived

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -18,6 +18,10 @@ class Theme < ApplicationRecord
   scope :popular, -> { order(theme_votes_count: :desc) }
   scope :active_themes, -> { where(status: :active) }
   scope :archived_themes, -> { where(status: :archived) }
+  scope :search_by_keyword, ->(keyword) {
+    return all if keyword.blank?
+    where("title ILIKE :q OR description ILIKE :q", q: "%#{sanitize_sql_like(keyword)}%")
+  }
 
   has_many :theme_votes, dependent: :destroy
   has_many :voters, through: :theme_votes, source: :user

--- a/app/views/themes/index.html.erb
+++ b/app/views/themes/index.html.erb
@@ -15,6 +15,26 @@
   <% end %>
 </div>
 
+<!-- Search Form -->
+<div class="card bg-base-100 shadow-md ring-1 ring-base-300 mb-6">
+  <div class="card-body">
+    <%= form_with url: themes_path, method: :get, local: true, class: "flex flex-wrap gap-4 items-end" do |f| %>
+      <div class="form-control flex-1 min-w-[200px]">
+        <%= f.label :keyword, "キーワード", class: "label" %>
+        <%= f.text_field :keyword, value: params[:keyword], placeholder: "タイトル・説明で検索", class: "input input-bordered w-full" %>
+      </div>
+      <div class="form-control w-48">
+        <%= f.label :category, "カテゴリ", class: "label" %>
+        <%= f.select :category, options_for_select(Theme.categories.map { |k, _| [Theme.human_enum_name(:category, k), k] }, params[:category]), { include_blank: "全て" }, class: "select select-bordered w-full" %>
+      </div>
+      <div class="flex gap-2">
+        <%= f.submit "検索", class: "btn btn-primary" %>
+        <%= link_to "クリア", themes_path, class: "btn btn-ghost" %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
 <!-- Theme List -->
 <div class="space-y-4">
   <% @themes.each do |theme| %>

--- a/spec/requests/themes_search_spec.rb
+++ b/spec/requests/themes_search_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe "Themes Search", type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  describe "GET /themes with search parameters" do
+    let!(:tech_theme) { create(:theme, title: "Rails勉強会", description: "Railsを学ぶ", category: :tech, status: :active) }
+    let!(:community_theme) { create(:theme, title: "コミュニティイベント", description: "交流会", category: :community, status: :active) }
+    let!(:archived_theme) { create(:theme, title: "過去のイベント", description: "Rails", category: :tech, status: :archived) }
+
+    context "without search parameters" do
+      it "displays all active themes" do
+        get themes_path
+        expect(response.body).to include(tech_theme.title)
+        expect(response.body).to include(community_theme.title)
+        expect(response.body).not_to include(archived_theme.title)
+      end
+    end
+
+    context "with keyword parameter" do
+      it "displays themes matching keyword in title" do
+        get themes_path, params: { keyword: "Rails" }
+        expect(response.body).to include(tech_theme.title)
+        expect(response.body).not_to include(community_theme.title)
+      end
+
+      it "displays themes matching keyword in description" do
+        get themes_path, params: { keyword: "交流" }
+        expect(response.body).to include(community_theme.title)
+        expect(response.body).not_to include(tech_theme.title)
+      end
+
+      it "is case insensitive" do
+        get themes_path, params: { keyword: "rails" }
+        expect(response.body).to include(tech_theme.title)
+      end
+    end
+
+    context "with category parameter" do
+      it "displays only themes of specified category" do
+        get themes_path, params: { category: "tech" }
+        expect(response.body).to include(tech_theme.title)
+        expect(response.body).not_to include(community_theme.title)
+      end
+    end
+
+    context "with both keyword and category parameters" do
+      it "displays themes matching both conditions" do
+        get themes_path, params: { keyword: "Rails", category: "tech" }
+        expect(response.body).to include(tech_theme.title)
+        expect(response.body).not_to include(community_theme.title)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Issue #73 の要件に従い、テーマ一覧にキーワード検索とカテゴリ絞り込み機能を追加しました。

## 変更内容

### 1. モデルスコープ
- `search_by_keyword`: タイトル・説明でILIKE検索
- SQLインジェクション対策: sanitize_sql_like 使用

### 2. コントローラー
- keyword/category パラメータに応じて絞り込み

### 3. 検索フォーム
- キーワード入力欄
- カテゴリ選択（任意）
- クリアボタン

### 4. テスト
- キーワード検索（title/description、大文字小文字区別なし）
- カテゴリ絞り込み
- 併用検索

## テスト結果
```bash
$ RAILS_ENV=test bundle exec rspec spec/requests/themes_search_spec.rb
6 examples, 0 failures
```

## Closes
Closes #73