### PR TITLE
ビューロジックをヘルパーに移動

### DIFF
--- a/app/helpers/profiles/availability_slots_helper.rb
+++ b/app/helpers/profiles/availability_slots_helper.rb
@@ -1,0 +1,35 @@
+module Profiles
+  module AvailabilitySlotsHelper
+    def wday_options
+      {
+        en: %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday],
+        jp: %w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日],
+        order: (0..6).to_a
+      }
+    end
+
+    def time_options
+      (0..47).map do |i|
+        m = i * 30
+        label = format("%02d:%02d", m / 60, m % 60)
+        [label, label]
+      end
+    end
+
+    def end_time_options
+      time_options + [["24:00", "24:00"]]
+    end
+
+    def minute_to_hhmm(minutes)
+      format("%02d:%02d", minutes / 60, minutes % 60)
+    end
+
+    def selected_time(obj, minute_attr, fallback_attr)
+      if obj.respond_to?(minute_attr) && !obj.public_send(minute_attr).nil?
+        minute_to_hhmm(obj.public_send(minute_attr))
+      else
+        obj.public_send(fallback_attr).to_s
+      end
+    end
+  end
+end

--- a/app/views/profiles/availability_slots/_local_variables.html.erb
+++ b/app/views/profiles/availability_slots/_local_variables.html.erb
@@ -1,27 +1,8 @@
-<%# ========== 曜日（0=日, ... 6=土）に統一（Date#wday） ========== %>
-<% wday_en = %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday] %>
-<% wday_jp = %w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日] %>
-<% wdays_order = (0..6).to_a %>
-
-<%# ========== 時刻オプション（30分刻み） ========== %>
-<% time_options =
-  (0..47).map do |i|
-    m = i * 30
-    label = format("%02d:%02d", m / 60, m % 60)
-    [label, label]
-  end
-%>
-<% end_time_options = time_options + [["24:00", "24:00"]] %>
-
-<%# ========== start_minute/end_minute を "HH:MM" に変換して selected を確実に当てる ========== %>
-<% minute_to_hhmm = ->(m) { format("%02d:%02d", m / 60, m % 60) } %>
-<% selected_hhmm = ->(obj, minute_attr, fallback_attr) do
-  if obj.respond_to?(minute_attr) && !obj.public_send(minute_attr).nil?
-    minute_to_hhmm.call(obj.public_send(minute_attr))
-  else
-    obj.public_send(fallback_attr).to_s
-  end
-end %>
+<%# ヘルパーから変数を取得 %>
+<% wday_data = wday_options %>
+<% wday_en = wday_data[:en] %>
+<% wday_jp = wday_data[:jp] %>
+<% wdays_order = wday_data[:order] %>
 
 <%# controller でセットされる想定 %>
 <% @category ||= (params[:category].presence || "tech") %>


### PR DESCRIPTION
## 概要
Issue #108 の要件に従い、`_local_variables.html.erb` のロジックをヘルパーに移動しました。

## 変更内容

### 新規ヘルパーメソッド
- `wday_options`: 曜日データ（英語/日本語/順序）
- `time_options`: 30分刻みの時刻選択肢
- `end_time_options`: 終了時刻選択肢（24:00含む）
- `minute_to_hhmm`: 分をHH:MM形式に変換
- `selected_time`: 選択値を計算

### ビュー簡素化
lambda定義やデータ構造構築をヘルパー呼び出しに置換。

## Closes
Closes #108