### PR TITLE
pendingモデルスペックを実装 (#112)

### DIFF
--- a/spec/models/availability_slot_spec.rb
+++ b/spec/models/availability_slot_spec.rb
@@ -1,5 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe AvailabilitySlot, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe 'enums' do
+    it { is_expected.to define_enum_for(:category).with_values(tech: 0, community: 1) }
+  end
+
+  describe 'validations' do
+    subject { build(:availability_slot) }
+
+    it { is_expected.to validate_presence_of(:category) }
+    it { is_expected.to validate_presence_of(:wday) }
+    it { is_expected.to validate_presence_of(:start_minute) }
+    it { is_expected.to validate_presence_of(:end_minute) }
+  end
 end

--- a/spec/models/theme_comment_spec.rb
+++ b/spec/models/theme_comment_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe ThemeComment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:theme) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:body) }
+    it { is_expected.to validate_length_of(:body).is_at_most(255) }
+  end
 end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -1,5 +1,73 @@
 require 'rails_helper'
 
 RSpec.describe Theme, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'associations' do
+    it { is_expected.to belong_to(:community) }
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_many(:theme_votes).dependent(:destroy) }
+    it { is_expected.to have_many(:voters).through(:theme_votes).source(:user) }
+    it { is_expected.to have_many(:theme_comments).dependent(:destroy) }
+    it { is_expected.to have_many(:rsvps).dependent(:destroy) }
+    it { is_expected.to have_many(:rsvp_users).through(:rsvps).source(:user) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:category) }
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_length_of(:title).is_at_most(100) }
+    it { is_expected.to validate_presence_of(:description) }
+    it { is_expected.to validate_length_of(:description).is_at_most(1000) }
+
+    context 'when secondary_enabled is true' do
+      subject { build(:theme, secondary_enabled: true) }
+      it { is_expected.to validate_presence_of(:secondary_label) }
+    end
+  end
+
+  describe 'enums' do
+    it { is_expected.to define_enum_for(:category).with_values(tech: 0, community: 1) }
+    it { is_expected.to define_enum_for(:status).with_values(active: 0, archived: 1) }
+  end
+
+  describe 'scopes' do
+    let!(:old_theme) { create(:theme, created_at: 2.days.ago, theme_votes_count: 5, status: :active) }
+    let!(:new_theme) { create(:theme, created_at: 1.day.ago, theme_votes_count: 10, status: :active) }
+    let!(:archived_theme) { create(:theme, status: :archived) }
+
+    describe '.recent' do
+      it 'returns themes ordered by created_at desc' do
+        expect(Theme.recent.where(id: [old_theme.id, new_theme.id, archived_theme.id])).to eq([archived_theme, new_theme, old_theme])
+      end
+    end
+
+    describe '.by_category' do
+      let!(:tech_theme) { create(:theme, category: :tech) }
+      let!(:community_theme) { create(:theme, category: :community) }
+
+      it 'returns themes of specified category' do
+        expect(Theme.by_category(:tech)).to include(tech_theme)
+        expect(Theme.by_category(:tech)).not_to include(community_theme)
+      end
+    end
+
+    describe '.popular' do
+      it 'returns themes ordered by theme_votes_count desc' do
+        expect(Theme.popular.first(2)).to eq([new_theme, old_theme])
+      end
+    end
+
+    describe '.active_themes' do
+      it 'returns only active themes' do
+        expect(Theme.active_themes).to include(old_theme, new_theme)
+        expect(Theme.active_themes).not_to include(archived_theme)
+      end
+    end
+
+    describe '.archived_themes' do
+      it 'returns only archived themes' do
+        expect(Theme.archived_themes).to include(archived_theme)
+        expect(Theme.archived_themes).not_to include(old_theme, new_theme)
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,48 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'associations' do
+    it { is_expected.to have_many(:themes).dependent(:destroy) }
+    it { is_expected.to have_many(:theme_votes).dependent(:destroy) }
+    it { is_expected.to have_many(:voted_themes).through(:theme_votes).source(:theme) }
+    it { is_expected.to have_many(:theme_comments).dependent(:destroy) }
+    it { is_expected.to have_many(:rsvps).dependent(:destroy) }
+    it { is_expected.to have_many(:rsvp_themes).through(:rsvps).source(:theme) }
+    it { is_expected.to have_many(:availability_slots).dependent(:destroy) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:nickname) }
+    it { is_expected.to validate_length_of(:nickname).is_at_most(50) }
+    it { is_expected.to validate_numericality_of(:cohort).only_integer.is_greater_than(0).allow_nil }
+  end
+
+  describe '#cohort_label' do
+    it 'returns formatted cohort when cohort is set' do
+      user = build(:user, cohort: 10)
+      expect(user.cohort_label).to eq("10期")
+    end
+
+    it 'returns "未設定" when cohort is 0' do
+      user = build(:user, cohort: 0)
+      expect(user.cohort_label).to eq("未設定")
+    end
+
+    it 'returns "未設定" when cohort is nil' do
+      user = build(:user, cohort: nil)
+      expect(user.cohort_label).to eq("未設定")
+    end
+  end
+
+  describe '.cohort_options' do
+    it 'returns distinct cohorts in ascending order' do
+      create(:user, cohort: 10)
+      create(:user, cohort: 5)
+      create(:user, cohort: 10)
+
+      expect(User.cohort_options).to include(5, 10)
+      expect(User.cohort_options.uniq).to eq(User.cohort_options)
+      expect(User.cohort_options).to eq(User.cohort_options.sort)
+    end
+  end
 end


### PR DESCRIPTION
## 概要
残存していたpendingモデルスペック4件を実装しました。

## 実装内容

### User (`spec/models/user_spec.rb`)
- associations: 7つのリレーション（themes, theme_votes, voted_themes, theme_comments, rsvps, rsvp_themes, availability_slots）をテスト
- validations: nickname（presence, 最大50文字）、cohort（整数、0より大きい、nil許可）をテスト
- `cohort_label`: 期の表示（10期、未設定）をテスト
- `cohort_options`: 重複排除・昇順ソートをテスト

### Theme (`spec/models/theme_spec.rb`)
- associations: 7つのリレーション（community, user, theme_votes, voters, theme_comments, rsvps, rsvp_users）をテスト
- validations: category, title（最大100文字）、description（最大1000文字）、secondary_label（secondary_enabled時）をテスト
- enums: category（tech/community）、status（active/archived）をテスト
- scopes: recent（作成日降順）、by_category（カテゴリフィルタ）、popular（投票数降順）、active_themes、archived_themesをテスト

### ThemeComment (`spec/models/theme_comment_spec.rb`)
- associations: user, theme とのリレーションをテスト
- validations: body（presence, 最大255文字）をテスト

### AvailabilitySlot (`spec/models/availability_slot_spec.rb`)
- associations: user とのリレーションをテスト
- enums: category（tech/community）をテスト
- validations: category, wday, start_minute, end_minute の存在チェックをテスト

## 検証
```bash
docker compose exec web bash -c "RAILS_ENV=test bundle exec rspec spec/models/"
# 67 examples, 0 failures
```

## 関連Issue
Closes #112