### PR TITLE
テーマの状態遷移（検討→確定→開催済）＋UI反映 (#127)

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -5,18 +5,22 @@ class Theme < ApplicationRecord
   belongs_to :user
 
   enum :category, { tech: 0, community: 1 }
-  enum :status, { active: 0, archived: 1 }
+  enum :status, { considering: 0, archived: 1, confirmed: 2, done: 3 }
 
   validates :category, presence: true
   validates :status, presence: true
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, presence: true, length: { maximum: 1000 }
   validates :secondary_label, presence: true, if: :secondary_enabled?
+  validates :converted_event_url,
+            format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]),
+                      message: "は有効なURLを入力してください" },
+            allow_blank: true
 
   scope :recent, -> { order(created_at: :desc) }
   scope :by_category, ->(category) { where(category: category) }
   scope :popular, -> { order(theme_votes_count: :desc) }
-  scope :active_themes, -> { where(status: :active) }
+  scope :active_themes, -> { where.not(status: :archived) }
   scope :archived_themes, -> { where(status: :archived) }
   scope :search_by_keyword, ->(keyword) {
     return all if keyword.blank?

--- a/app/views/themes/_event_url.html.erb
+++ b/app/views/themes/_event_url.html.erb
@@ -1,0 +1,10 @@
+<% if theme.converted_event_url.present? && (theme.confirmed? || theme.done?) %>
+  <div class="mt-2 flex items-center gap-2">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-base-content/60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+    </svg>
+    <%= link_to "イベントページ", theme.converted_event_url,
+          target: "_blank", rel: "noopener noreferrer",
+          class: "link link-primary text-sm" %>
+  </div>
+<% end %>

--- a/app/views/themes/_form.html.erb
+++ b/app/views/themes/_form.html.erb
@@ -54,6 +54,16 @@
     <%= f.text_area :description, rows: 6, maxlength: 1000, class: "textarea textarea-bordered w-full ring-1 ring-base-300 focus:ring-2 focus:ring-primary", placeholder: "テーマの概要や目的を記載してください（最大1000文字）" %>
   </fieldset>
 
+  <% if theme.confirmed? || theme.done? %>
+    <fieldset class="fieldset">
+      <%= f.label :converted_event_url, "イベントURL", class: "fieldset-legend" %>
+      <%= f.url_field :converted_event_url,
+            class: "input input-bordered w-full ring-1 ring-base-300 focus:ring-2 focus:ring-primary",
+            placeholder: "https://connpass.com/event/..." %>
+      <span class="label-text-alt text-base-content/60">確定したイベントのURLを入力してください</span>
+    </fieldset>
+  <% end %>
+
   <div class="flex items-center gap-3 pt-2">
     <%= f.submit class: "btn btn-primary" %>
     <%= link_to "キャンセル", themes_path, class: "btn btn-ghost" %>

--- a/app/views/themes/_status_badge.html.erb
+++ b/app/views/themes/_status_badge.html.erb
@@ -1,0 +1,11 @@
+<%# theme のステータスに応じたバッジを表示 %>
+<% case theme.status %>
+<% when "considering" %>
+  <%# considering は通常表示なのでバッジなし %>
+<% when "confirmed" %>
+  <span class="badge badge-success">確定</span>
+<% when "done" %>
+  <span class="badge badge-ghost">開催済</span>
+<% when "archived" %>
+  <span class="badge badge-ghost">アーカイブ</span>
+<% end %>

--- a/app/views/themes/_transition_buttons.html.erb
+++ b/app/views/themes/_transition_buttons.html.erb
@@ -1,0 +1,38 @@
+<% if current_user == theme.user %>
+  <% case theme.status %>
+  <% when "considering" %>
+    <%# 「確定にする」ボタン（モーダルでURL入力）%>
+    <button class="btn btn-success btn-sm" onclick="document.getElementById('confirm-modal').showModal()">
+      確定にする
+    </button>
+    <dialog id="confirm-modal" class="modal">
+      <div class="modal-box">
+        <h3 class="text-lg font-bold">テーマを確定にする</h3>
+        <%= form_with url: transition_theme_path(theme), method: :patch, local: true do |f| %>
+          <%= f.hidden_field :status, name: "theme[status]", value: "confirmed" %>
+          <fieldset class="fieldset mt-4">
+            <label class="fieldset-legend">イベントURL（任意）</label>
+            <%= f.url_field :converted_event_url,
+                name: "theme[converted_event_url]",
+                value: theme.converted_event_url,
+                placeholder: "https://connpass.com/event/...",
+                class: "input input-bordered w-full" %>
+          </fieldset>
+          <div class="modal-action">
+            <button type="button" class="btn btn-ghost" onclick="this.closest('dialog').close()">キャンセル</button>
+            <%= f.submit "確定にする", class: "btn btn-success" %>
+          </div>
+        <% end %>
+      </div>
+      <form method="dialog" class="modal-backdrop"><button>close</button></form>
+    </dialog>
+
+  <% when "confirmed" %>
+    <%# 「開催済にする」ボタン %>
+    <%= button_to "開催済にする", transition_theme_path(theme),
+          method: :patch,
+          params: { theme: { status: "done" } },
+          class: "btn btn-ghost btn-sm",
+          data: { turbo_confirm: "開催済に変更しますか？" } %>
+  <% end %>
+<% end %>

--- a/app/views/themes/archived.html.erb
+++ b/app/views/themes/archived.html.erb
@@ -13,7 +13,7 @@
               <div class="flex-1">
                 <h2 class="card-title">
                   <%= theme.title %>
-                  <div class="badge badge-ghost badge-sm">アーカイブ</div>
+                  <%= render "themes/status_badge", theme: theme %>
                 </h2>
                 <p class="text-sm text-base-content/60"><%= truncate(theme.description, length: 100) %></p>
               </div>

--- a/app/views/themes/index.html.erb
+++ b/app/views/themes/index.html.erb
@@ -44,6 +44,7 @@
           <div class="min-w-0 flex-1">
             <div class="mb-2 flex flex-wrap items-center gap-2">
               <span class="badge badge-primary"><%= Theme.human_enum_name(:category, theme.category) %></span>
+              <%= render "themes/status_badge", theme: theme %>
               <span class="text-xs text-base-content/60">
                 <%= l(theme.created_at, format: :short) %>
               </span>

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -12,6 +12,7 @@
       <div class="min-w-0 flex-1">
         <div class="mb-2 flex flex-wrap items-center gap-2">
           <span class="badge badge-primary badge-lg"><%= Theme.human_enum_name(:category, @theme.category) %></span>
+          <%= render "themes/status_badge", theme: @theme %>
           <span class="text-sm text-base-content/60">
             <%= l(@theme.created_at, format: :short) %>
           </span>
@@ -21,6 +22,7 @@
       
       <div class="flex flex-wrap items-start gap-2">
         <%= render "themes/vote_section", theme: @theme %>
+        <%= render "themes/transition_buttons", theme: @theme %>
         <% if user_signed_in? && current_user == @theme.user %>
           <%= link_to "編集", edit_theme_path(@theme), class: "btn btn-ghost btn-sm" %>
           <%= button_to "削除", theme_path(@theme),
@@ -37,6 +39,8 @@
     <div class="prose max-w-none whitespace-pre-wrap leading-relaxed">
       <%= @theme.description %>
     </div>
+
+    <%= render "themes/event_url", theme: @theme %>
   </div>
 </div>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,9 +19,15 @@ ja:
         title: "タイトル"
         description: "説明"
         secondary_label: "第2ボタン名"
+        converted_event_url: "イベントURL"
         categories:
           tech: "技術系"
           community: "交流系"
+        statuses:
+          considering: "検討中"
+          archived: "アーカイブ"
+          confirmed: "確定"
+          done: "開催済"
       theme_comment:
         body: "コメント"
       availability_slot:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,9 @@ end
   collection do
     get :archived
   end
+  member do
+    patch :transition
+  end
   scope module: :themes do
     resource  :vote,           only: %i[create destroy]
     resources :theme_comments, only: %i[create destroy]

--- a/db/migrate/20260211232143_add_converted_event_url_to_themes.rb
+++ b/db/migrate/20260211232143_add_converted_event_url_to_themes.rb
@@ -1,0 +1,5 @@
+class AddConvertedEventUrlToThemes < ActiveRecord::Migration[7.2]
+  def change
+    add_column :themes, :converted_event_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_11_164650) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_11_232143) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -83,6 +83,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_11_164650) do
     t.string "secondary_label"
     t.integer "theme_votes_count", default: 0, null: false
     t.integer "status", default: 0, null: false
+    t.string "converted_event_url"
     t.index ["community_id"], name: "index_themes_on_community_id"
     t.index ["user_id"], name: "index_themes_on_user_id"
   end

--- a/spec/factories/themes.rb
+++ b/spec/factories/themes.rb
@@ -5,5 +5,19 @@ FactoryBot.define do
     category { :tech }
     sequence(:title) { |n| "テーマ#{n}" }
     description { "テーマの説明文" }
+
+    trait :confirmed do
+      status { :confirmed }
+      converted_event_url { "https://connpass.com/event/12345/" }
+    end
+
+    trait :done do
+      status { :done }
+      converted_event_url { "https://connpass.com/event/12345/" }
+    end
+
+    trait :archived do
+      status { :archived }
+    end
   end
 end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -26,17 +26,43 @@ RSpec.describe Theme, type: :model do
 
   describe 'enums' do
     it { is_expected.to define_enum_for(:category).with_values(tech: 0, community: 1) }
-    it { is_expected.to define_enum_for(:status).with_values(active: 0, archived: 1) }
+    it { is_expected.to define_enum_for(:status).with_values(considering: 0, archived: 1, confirmed: 2, done: 3) }
+  end
+
+  describe 'validations' do
+    describe 'converted_event_url' do
+      it '有効なURLを許可する' do
+        theme = build(:theme, converted_event_url: 'https://connpass.com/event/12345/')
+        expect(theme).to be_valid
+      end
+
+      it '空を許可する' do
+        theme = build(:theme, converted_event_url: '')
+        expect(theme).to be_valid
+      end
+
+      it 'nilを許可する' do
+        theme = build(:theme, converted_event_url: nil)
+        expect(theme).to be_valid
+      end
+
+      it '不正なURLを拒否する' do
+        theme = build(:theme, converted_event_url: 'not-a-url')
+        expect(theme).not_to be_valid
+        expect(theme.errors[:converted_event_url]).to be_present
+      end
+    end
   end
 
   describe 'scopes' do
-    let!(:old_theme) { create(:theme, created_at: 2.days.ago, theme_votes_count: 5, status: :active) }
-    let!(:new_theme) { create(:theme, created_at: 1.day.ago, theme_votes_count: 10, status: :active) }
+    let!(:considering_theme) { create(:theme, created_at: 2.days.ago, theme_votes_count: 5, status: :considering) }
+    let!(:confirmed_theme) { create(:theme, created_at: 1.day.ago, theme_votes_count: 10, status: :confirmed) }
+    let!(:done_theme) { create(:theme, status: :done) }
     let!(:archived_theme) { create(:theme, status: :archived) }
 
     describe '.recent' do
       it 'returns themes ordered by created_at desc' do
-        expect(Theme.recent.where(id: [old_theme.id, new_theme.id, archived_theme.id])).to eq([archived_theme, new_theme, old_theme])
+        expect(Theme.recent.where(id: [considering_theme.id, confirmed_theme.id, done_theme.id])).to eq([done_theme, confirmed_theme, considering_theme])
       end
     end
 
@@ -52,21 +78,22 @@ RSpec.describe Theme, type: :model do
 
     describe '.popular' do
       it 'returns themes ordered by theme_votes_count desc' do
-        expect(Theme.popular.first(2)).to eq([new_theme, old_theme])
+        expect(Theme.popular.where(id: [considering_theme.id, confirmed_theme.id])).to eq([confirmed_theme, considering_theme])
       end
     end
 
     describe '.active_themes' do
-      it 'returns only active themes' do
-        expect(Theme.active_themes).to include(old_theme, new_theme)
-        expect(Theme.active_themes).not_to include(archived_theme)
+      it 'archived以外のすべてのテーマを返す' do
+        result = Theme.active_themes
+        expect(result).to include(considering_theme, confirmed_theme, done_theme)
+        expect(result).not_to include(archived_theme)
       end
     end
 
     describe '.archived_themes' do
       it 'returns only archived themes' do
         expect(Theme.archived_themes).to include(archived_theme)
-        expect(Theme.archived_themes).not_to include(old_theme, new_theme)
+        expect(Theme.archived_themes).not_to include(considering_theme, confirmed_theme, done_theme)
       end
     end
   end

--- a/spec/requests/themes_archived_spec.rb
+++ b/spec/requests/themes_archived_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Themes Archived", type: :request do
   before { sign_in user }
 
   describe "GET /themes/archived" do
-    let!(:active_theme) { create(:theme, status: :active) }
+    let!(:active_theme) { create(:theme, status: :considering) }
     let!(:archived_theme) { create(:theme, status: :archived) }
 
     it "returns http success" do

--- a/spec/requests/themes_search_spec.rb
+++ b/spec/requests/themes_search_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Themes Search", type: :request do
   before { sign_in user }
 
   describe "GET /themes with search parameters" do
-    let!(:tech_theme) { create(:theme, title: "Rails勉強会", description: "Railsを学ぶ", category: :tech, status: :active) }
-    let!(:community_theme) { create(:theme, title: "コミュニティイベント", description: "交流会", category: :community, status: :active) }
+    let!(:tech_theme) { create(:theme, title: "Rails勉強会", description: "Railsを学ぶ", category: :tech, status: :considering) }
+    let!(:community_theme) { create(:theme, title: "コミュニティイベント", description: "交流会", category: :community, status: :considering) }
     let!(:archived_theme) { create(:theme, title: "過去のイベント", description: "Rails", category: :tech, status: :archived) }
 
     context "without search parameters" do

--- a/spec/requests/themes_transition_spec.rb
+++ b/spec/requests/themes_transition_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe "Themes Transition", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  before { sign_in user }
+
+  describe "PATCH /themes/:id/transition" do
+    context "considering -> confirmed" do
+      let(:theme) { create(:theme, user: user, status: :considering) }
+
+      it "テーマを確定状態に変更できる" do
+        patch transition_theme_path(theme), params: { theme: { status: "confirmed", converted_event_url: "https://example.com" } }
+        expect(theme.reload).to be_confirmed
+        expect(theme.converted_event_url).to eq("https://example.com")
+        expect(response).to redirect_to(theme)
+      end
+
+      it "URLなしでも確定にできる" do
+        patch transition_theme_path(theme), params: { theme: { status: "confirmed" } }
+        expect(theme.reload).to be_confirmed
+      end
+    end
+
+    context "confirmed -> done" do
+      let(:theme) { create(:theme, :confirmed, user: user) }
+
+      it "テーマを開催済に変更できる" do
+        patch transition_theme_path(theme), params: { theme: { status: "done" } }
+        expect(theme.reload).to be_done
+        expect(response).to redirect_to(theme)
+      end
+    end
+
+    context "不正な遷移" do
+      let(:theme) { create(:theme, user: user, status: :done) }
+
+      it "done から他の状態への遷移を拒否する" do
+        patch transition_theme_path(theme), params: { theme: { status: "considering" } }
+        expect(theme.reload).to be_done
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    context "他ユーザーのテーマ" do
+      let(:theme) { create(:theme, user: other_user, status: :considering) }
+
+      it "オーナー以外は遷移できない" do
+        patch transition_theme_path(theme), params: { theme: { status: "confirmed" } }
+        expect(theme.reload).to be_considering
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
テーマに状態遷移（検討→確定→開催済）を追加し、UIに反映しました。

## 実装内容

### モデル変更
- `status` enum拡張: `{ considering: 0, archived: 1, confirmed: 2, done: 3 }`
  - `active(0)` → `considering(0)` に改名
  - `confirmed(2)`, `done(3)` を新規追加
- `converted_event_url` カラム追加（確定時のイベントURL）
- URLバリデーション追加（http/https形式、空許容）
- `active_themes` スコープ修正: `where.not(status: :archived)` に変更

### コントローラー・ルーティング
- `transition` アクション追加（状態遷移ルール実装）
  - considering → confirmed/archived
  - confirmed → done/archived
  - done/archived → 変更不可
- `PATCH /themes/:id/transition` ルート追加

### UI変更
- ステータスバッジ表示（確定/開催済/アーカイブ）
- 状態遷移ボタン
  - 検討中: 「確定にする」ボタン（モーダルでURL入力）
  - 確定: 「開催済にする」ボタン
- イベントURL表示（確定・開催済時）
- フォームにURL入力欄追加（確定・開催済時の編集）

### テスト
- ファクトリに trait追加（:confirmed, :done, :archived）
- 既存テスト修正（active → considering）
- モデルスペック追加（新enum、URLバリデーション）
- リクエストスペック新規作成（transition）

## 検証
```bash
docker compose exec web bash -c "RAILS_ENV=test bundle exec rspec spec/models/theme_spec.rb spec/requests/"
# 37 examples, 0 failures
```

## 関連Issue
Closes #127