### PR TITLE
開催候補日自動提案（参加可能時間集計）を実装

### DIFF
--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -133,5 +133,7 @@ class ThemesController < ApplicationController
       cohort: @cohort,
       category: @availability_category
     )
+
+    @suggested_slots = Availability::SuggestSlots.call(@availability_counts)
   end
 end

--- a/app/services/availability/suggest_slots.rb
+++ b/app/services/availability/suggest_slots.rb
@@ -1,0 +1,66 @@
+module Availability
+  class SuggestSlots
+    SLOTS_PER_DAY = 48
+    MIN_DURATION_SLOTS = 2 # 1時間（30分×2）以上
+    TOP_N = 3
+
+    # counts: 7×48 の2次元配列（AggregateCounts.call の戻り値）
+    # min_participants: 最低参加人数（これ未満のスロットは候補外）
+    def self.call(counts, min_participants: 1)
+      return [] if counts.blank?
+
+      candidates = []
+
+      counts.each_with_index do |day_counts, wday|
+        blocks = find_contiguous_blocks(day_counts, wday, min_participants)
+        candidates.concat(blocks)
+      end
+
+      candidates
+        .select { |b| b[:slots] >= MIN_DURATION_SLOTS }
+        .sort_by { |b| [-b[:min_count], -b[:slots]] }
+        .first(TOP_N)
+    end
+
+    def self.find_contiguous_blocks(day_counts, wday, min_participants)
+      blocks = []
+      current_start = nil
+      current_min = nil
+
+      day_counts.each_with_index do |count, slot|
+        if count >= min_participants
+          if current_start.nil?
+            current_start = slot
+            current_min = count
+          else
+            current_min = [current_min, count].min
+          end
+        else
+          if current_start
+            blocks << build_block(wday, current_start, slot, current_min)
+            current_start = nil
+            current_min = nil
+          end
+        end
+      end
+
+      if current_start
+        blocks << build_block(wday, current_start, SLOTS_PER_DAY, current_min)
+      end
+
+      blocks
+    end
+
+    def self.build_block(wday, start_slot, end_slot, min_count)
+      {
+        wday: wday,
+        start_minute: start_slot * 30,
+        end_minute: end_slot * 30,
+        min_count: min_count,
+        slots: end_slot - start_slot
+      }
+    end
+
+    private_class_method :find_contiguous_blocks, :build_block
+  end
+end

--- a/app/views/availability/_suggested_slots.html.erb
+++ b/app/views/availability/_suggested_slots.html.erb
@@ -1,0 +1,29 @@
+<div class="rounded-lg border border-base-300 bg-base-100 p-4 shadow-sm">
+  <h3 class="mb-3 text-lg font-bold">開催候補枠（Top <%= suggested_slots.size %>）</h3>
+
+  <% if suggested_slots.present? %>
+    <div class="grid gap-3 sm:grid-cols-3">
+      <% suggested_slots.each_with_index do |slot, i| %>
+        <div class="flex items-start gap-3 rounded-lg border border-base-300 bg-base-200/50 p-3">
+          <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-primary-content font-bold text-sm">
+            <%= i + 1 %>
+          </div>
+          <div class="min-w-0">
+            <div class="font-bold">
+              <%= AvailabilityHelper::WDAY_LABELS[slot[:wday]] %>曜日
+            </div>
+            <div class="text-sm">
+              <%= minutes_to_hhmm(slot[:start_minute]) %>〜<%= minutes_to_hhmm(slot[:end_minute]) %>
+              <span class="text-base-content/60">（<%= slot[:slots] / 2 %>時間<%= slot[:slots].odd? ? "30分" : "" %>）</span>
+            </div>
+            <div class="mt-1 text-sm">
+              <span class="badge badge-info badge-sm">最低 <%= slot[:min_count] %>人 参加可能</span>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="text-sm text-base-content/60">参加可能データが不足しているため、候補を表示できません。</p>
+  <% end %>
+</div>

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -51,6 +51,12 @@
 
     <%= render "themes/comment_form", theme: @theme, theme_comment: @theme_comment %>
 
+    <% if @availability_supported %>
+      <div class="mt-4">
+        <%= render "availability/suggested_slots", suggested_slots: @suggested_slots || [] %>
+      </div>
+    <% end %>
+
     <div class="mt-4">
       <% if @availability_supported %>
         <%= render "availability/aggregate_frame",

--- a/spec/requests/themes_suggested_slots_spec.rb
+++ b/spec/requests/themes_suggested_slots_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "Themes Suggested Slots", type: :request do
+  let(:user) { create(:user, cohort: 1) }
+
+  before { sign_in user }
+
+  describe "GET /themes/:id" do
+    context "参加可能データがある場合" do
+      let(:theme) { create(:theme, user: user, category: :tech) }
+
+      before do
+        # 月曜 19:00-20:00 に2人参加可能
+        user2 = create(:user, cohort: 1)
+        create(:availability_slot, user: user, category: "tech", wday: 1, start_minute: 1140, end_minute: 1200)
+        create(:availability_slot, user: user2, category: "tech", wday: 1, start_minute: 1140, end_minute: 1200)
+      end
+
+      it "候補枠が表示される" do
+        get theme_path(theme)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("開催候補枠")
+        expect(response.body).to include("19:00")
+        expect(response.body).to include("20:00")
+      end
+    end
+
+    context "参加可能データがない場合" do
+      let(:theme) { create(:theme, user: user, category: :tech) }
+
+      it "候補なしメッセージが表示される" do
+        get theme_path(theme)
+
+        expect(response).to have_http_status(:ok)
+        # 候補枠セクションが表示されることを確認
+        expect(response.body).to include("開催候補枠")
+      end
+    end
+  end
+end

--- a/spec/services/availability/suggest_slots_spec.rb
+++ b/spec/services/availability/suggest_slots_spec.rb
@@ -1,0 +1,147 @@
+require "rails_helper"
+
+RSpec.describe Availability::SuggestSlots do
+  describe ".call" do
+    def empty_counts
+      Array.new(7) { Array.new(48, 0) }
+    end
+
+    context "データがない場合" do
+      it "空配列を返す" do
+        expect(described_class.call(empty_counts)).to eq([])
+      end
+
+      it "nilを渡しても空配列を返す" do
+        expect(described_class.call(nil)).to eq([])
+      end
+    end
+
+    context "1時間未満のスロットのみの場合" do
+      it "候補に含まれない" do
+        counts = empty_counts
+        # 月曜 09:00-09:30 のみ（1スロット）
+        counts[1][18] = 3
+
+        expect(described_class.call(counts)).to eq([])
+      end
+    end
+
+    context "1時間以上の連続スロットがある場合" do
+      it "候補として返す" do
+        counts = empty_counts
+        # 月曜 09:00-10:00（2スロット）
+        counts[1][18] = 3
+        counts[1][19] = 3
+
+        result = described_class.call(counts)
+
+        expect(result.size).to eq(1)
+        expect(result[0]).to include(
+          wday: 1,
+          start_minute: 540,
+          end_minute: 600,
+          min_count: 3,
+          slots: 2
+        )
+      end
+    end
+
+    context "複数の候補がある場合" do
+      it "min_count降順でソートされる" do
+        counts = empty_counts
+        # 月曜 09:00-10:00: 2人
+        counts[1][18] = 2
+        counts[1][19] = 2
+        # 水曜 19:00-20:00: 5人
+        counts[3][38] = 5
+        counts[3][39] = 5
+
+        result = described_class.call(counts)
+
+        expect(result.size).to eq(2)
+        expect(result[0][:wday]).to eq(3)
+        expect(result[0][:min_count]).to eq(5)
+        expect(result[1][:wday]).to eq(1)
+        expect(result[1][:min_count]).to eq(2)
+      end
+
+      it "同じmin_countならslots（時間の長さ）降順" do
+        counts = empty_counts
+        # 月曜 09:00-10:00: 3人（2スロット）
+        counts[1][18] = 3
+        counts[1][19] = 3
+        # 水曜 19:00-21:00: 3人（4スロット）
+        counts[3][38] = 3
+        counts[3][39] = 3
+        counts[3][40] = 3
+        counts[3][41] = 3
+
+        result = described_class.call(counts)
+
+        expect(result[0][:wday]).to eq(3)
+        expect(result[0][:slots]).to eq(4)
+      end
+    end
+
+    context "Top 3の制限" do
+      it "最大3件まで返す" do
+        counts = empty_counts
+        # 4つの候補を作成
+        [0, 1, 2, 3].each do |wday|
+          counts[wday][18] = 3
+          counts[wday][19] = 3
+        end
+
+        result = described_class.call(counts)
+
+        expect(result.size).to eq(3)
+      end
+    end
+
+    context "連続ブロックのmin_count計算" do
+      it "ブロック内の最小値がmin_countになる" do
+        counts = empty_counts
+        # 月曜 09:00-10:30: [5, 2, 5]
+        counts[1][18] = 5
+        counts[1][19] = 2
+        counts[1][20] = 5
+
+        result = described_class.call(counts)
+
+        expect(result[0][:min_count]).to eq(2)
+      end
+    end
+
+    context "min_participants引数" do
+      it "指定した人数未満のスロットを除外する" do
+        counts = empty_counts
+        # 月曜 09:00-10:00: 1人
+        counts[1][18] = 1
+        counts[1][19] = 1
+        # 水曜 19:00-20:00: 3人
+        counts[3][38] = 3
+        counts[3][39] = 3
+
+        result = described_class.call(counts, min_participants: 2)
+
+        expect(result.size).to eq(1)
+        expect(result[0][:wday]).to eq(3)
+      end
+    end
+
+    context "日をまたがないこと" do
+      it "異なる曜日のスロットは別ブロックになる" do
+        counts = empty_counts
+        # 月曜 23:30-24:00
+        counts[1][47] = 3
+        # 火曜 00:00-00:30
+        counts[2][0] = 3
+
+        result = described_class.call(counts)
+
+        # 各1スロット（30分）のみなので候補なし
+        expect(result).to eq([])
+      end
+    end
+  end
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -4,5 +4,6 @@ RSpec.configure do |config|
   # allow_browserチェックをスキップするヘルパー
   config.before(:each, type: :request) do
     allow_any_instance_of(ApplicationController).to receive(:allow_browser).and_return(true)
+    host! "localhost"
   end
 end


### PR DESCRIPTION
## Summary
- `Availability::SuggestSlots` サービスを新規作成し、7×48集計行列から参加可能人数が多い上位3件の候補時間帯を抽出
- テーマ詳細ページに候補枠セクション（曜日・時間帯・最低参加人数）を表示
- テスト環境のHost Authorization問題を修正（`host! "localhost"`）

## 変更ファイル
| ファイル | 種類 | 役割 |
|----------|------|------|
| `app/services/availability/suggest_slots.rb` | 新規 | 候補枠抽出ロジック |
| `app/views/availability/_suggested_slots.html.erb` | 新規 | 候補枠表示パーシャル |
| `app/controllers/themes_controller.rb` | 修正 | SuggestSlots呼び出し追加 |
| `app/views/themes/show.html.erb` | 修正 | 候補枠パーシャル表示追加 |
| `spec/services/availability/suggest_slots_spec.rb` | 新規 | サービスのユニットテスト（10件） |
| `spec/requests/themes_suggested_slots_spec.rb` | 新規 | リクエストスペック（2件） |
| `spec/support/devise.rb` | 修正 | テスト用ホスト設定追加 |

## Test plan
- [x] SuggestSlots サービスのユニットテスト（10ケース）パス
- [x] リクエストスペック（候補あり/なし）パス
- [x] 既存モデルスペック130件全パス

Closes #128