### PR TITLE
RuboCopのスタイル違反を修正

### DIFF
--- a/app/controllers/themes/rsvps_controller.rb
+++ b/app/controllers/themes/rsvps_controller.rb
@@ -14,7 +14,7 @@ module Themes
       # secondary_interest を更新しようとしている場合、参加表明が attending でなければ拒否
       if params_to_update.key?(:secondary_interest) && !@rsvp.attending?
         # secondary_interest のみの更新の場合はエラー
-        if params_to_update.keys.sort == [:secondary_interest]
+        if params_to_update.keys.sort == [ :secondary_interest ]
           @rsvp_counts = @theme.rsvp_counts
           flash.now[:alert] = "参加表明が必要です。"
           render :update, status: :unprocessable_entity

--- a/app/helpers/profiles/availability_slots_helper.rb
+++ b/app/helpers/profiles/availability_slots_helper.rb
@@ -12,12 +12,12 @@ module Profiles
       (0..47).map do |i|
         m = i * 30
         label = format("%02d:%02d", m / 60, m % 60)
-        [label, label]
+        [ label, label ]
       end
     end
 
     def end_time_options
-      time_options + [["24:00", "24:00"]]
+      time_options + [ [ "24:00", "24:00" ] ]
     end
 
     def minute_to_hhmm(minutes)

--- a/app/services/availability/suggest_slots.rb
+++ b/app/services/availability/suggest_slots.rb
@@ -18,7 +18,7 @@ module Availability
 
       candidates
         .select { |b| b[:slots] >= MIN_DURATION_SLOTS }
-        .sort_by { |b| [-b[:min_count], -b[:slots]] }
+        .sort_by { |b| [ -b[:min_count], -b[:slots] ] }
         .first(TOP_N)
     end
 
@@ -33,7 +33,7 @@ module Availability
             current_start = slot
             current_min = count
           else
-            current_min = [current_min, count].min
+            current_min = [ current_min, count ].min
           end
         else
           if current_start

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Theme, type: :model do
 
     describe '.recent' do
       it 'returns themes ordered by created_at desc' do
-        expect(Theme.recent.where(id: [considering_theme.id, confirmed_theme.id, done_theme.id])).to eq([done_theme, confirmed_theme, considering_theme])
+        expect(Theme.recent.where(id: [ considering_theme.id, confirmed_theme.id, done_theme.id ])).to eq([ done_theme, confirmed_theme, considering_theme ])
       end
     end
 
@@ -78,7 +78,7 @@ RSpec.describe Theme, type: :model do
 
     describe '.popular' do
       it 'returns themes ordered by theme_votes_count desc' do
-        expect(Theme.popular.where(id: [considering_theme.id, confirmed_theme.id])).to eq([confirmed_theme, considering_theme])
+        expect(Theme.popular.where(id: [ considering_theme.id, confirmed_theme.id ])).to eq([ confirmed_theme, considering_theme ])
       end
     end
 

--- a/spec/services/availability/suggest_slots_spec.rb
+++ b/spec/services/availability/suggest_slots_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Availability::SuggestSlots do
       it "最大3件まで返す" do
         counts = empty_counts
         # 4つの候補を作成
-        [0, 1, 2, 3].each do |wday|
+        [ 0, 1, 2, 3 ].each do |wday|
           counts[wday][18] = 3
           counts[wday][19] = 3
         end


### PR DESCRIPTION
## 概要
PR #149～#154でマージされたコードのRuboCopスタイル違反を修正しました。

## 修正内容
- `Layout/SpaceInsideArrayLiteralBrackets` 違反を解消
- 配列リテラルの角括弧内にスペースを追加

## 影響範囲
- コードスタイルのみの修正
- ロジックの変更なし

## 修正ファイル
- app/controllers/themes/rsvps_controller.rb
- app/helpers/profiles/availability_slots_helper.rb
- app/services/availability/suggest_slots.rb
- spec/models/theme_spec.rb
- spec/services/availability/suggest_slots_spec.rb