### PR TITLE
Bullet gemの開発環境設定を有効化 (#116)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -83,4 +83,14 @@ Rails.application.configure do
 }
 
   config.action_mailer.perform_deliveries = true # メール送信を有効にする
+
+  # Bullet gem の設定（N+1クエリ検出）
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+    Bullet.add_footer = true
+  end
 end


### PR DESCRIPTION
## 概要
N+1クエリ検出のため、Bullet gemの開発環境設定を有効化しました。

## 変更内容
- `config/environments/development.rb`にBullet設定を追加
  - `Bullet.enable = true`: Bullet機能を有効化
  - `Bullet.alert = true`: ブラウザアラート表示
  - `Bullet.bullet_logger = true`: `log/bullet.log`への出力
  - `Bullet.console = true`: ブラウザコンソールへの出力
  - `Bullet.rails_logger = true`: Railsログへの出力
  - `Bullet.add_footer = true`: ページ下部に警告を表示

## テスト方法
- [x] 開発サーバーを再起動して設定反映を確認
- [ ] テーマ一覧など複数のページにアクセスしてBulletが動作することを確認
- [ ] N+1クエリが発生した場合、画面下部に警告が表示されることを確認

Closes #116