### PR TITLE
開催候補日自動提案アルゴリズムを改善 (#128)

### DIFF
--- a/app/services/availability/suggest_slots.rb
+++ b/app/services/availability/suggest_slots.rb
@@ -2,6 +2,7 @@ module Availability
   class SuggestSlots
     SLOTS_PER_DAY = 48
     MIN_DURATION_SLOTS = 2 # 1時間（30分×2）以上
+    MAX_DURATION_SLOTS = 8 # 4時間（30分×8）以下
     TOP_N = 3
 
     # counts: 7×48 の2次元配列（AggregateCounts.call の戻り値）
@@ -18,7 +19,7 @@ module Availability
 
       candidates
         .select { |b| b[:slots] >= MIN_DURATION_SLOTS }
-        .sort_by { |b| [ -b[:min_count], -b[:slots] ] }
+        .sort_by { |b| [ -b[:avg_count], -b[:min_count], -b[:slots] ] }
         .first(TOP_N)
     end
 
@@ -37,7 +38,7 @@ module Availability
           end
         else
           if current_start
-            blocks << build_block(wday, current_start, slot, current_min)
+            blocks.concat(process_block(wday, current_start, slot, current_min, day_counts))
             current_start = nil
             current_min = nil
           end
@@ -45,22 +46,63 @@ module Availability
       end
 
       if current_start
-        blocks << build_block(wday, current_start, SLOTS_PER_DAY, current_min)
+        blocks.concat(process_block(wday, current_start, SLOTS_PER_DAY, current_min, day_counts))
       end
 
       blocks
     end
 
-    def self.build_block(wday, start_slot, end_slot, min_count)
+    def self.process_block(wday, start_slot, end_slot, min_count, day_counts)
+      slots = end_slot - start_slot
+
+      # MAX_DURATION_SLOTS以下ならそのまま返す
+      if slots <= MAX_DURATION_SLOTS
+        avg_count = calculate_avg_count(day_counts, start_slot, end_slot)
+        return [ build_block(wday, start_slot, end_slot, min_count, avg_count) ]
+      end
+
+      # MAX_DURATION_SLOTSを超える場合、スライディングウィンドウで最適なサブウィンドウを抽出
+      best_window = find_best_window(wday, start_slot, end_slot, day_counts)
+      best_window ? [ best_window ] : []
+    end
+
+    def self.find_best_window(wday, start_slot, end_slot, day_counts)
+      best_avg = -1
+      best_window = nil
+
+      # スライディングウィンドウで最もavg_countが高い区間を探す
+      (start_slot..end_slot - MAX_DURATION_SLOTS).each do |window_start|
+        window_end = window_start + MAX_DURATION_SLOTS
+        avg_count = calculate_avg_count(day_counts, window_start, window_end)
+        min_count = day_counts[window_start...window_end].min
+
+        if avg_count > best_avg
+          best_avg = avg_count
+          best_window = build_block(wday, window_start, window_end, min_count, avg_count)
+        end
+      end
+
+      best_window
+    end
+
+    def self.calculate_avg_count(day_counts, start_slot, end_slot)
+      slot_range = day_counts[start_slot...end_slot]
+      return 0.0 if slot_range.empty?
+
+      slot_range.sum.to_f / slot_range.size
+    end
+
+    def self.build_block(wday, start_slot, end_slot, min_count, avg_count)
       {
         wday: wday,
         start_minute: start_slot * 30,
         end_minute: end_slot * 30,
         min_count: min_count,
+        avg_count: avg_count,
         slots: end_slot - start_slot
       }
     end
 
-    private_class_method :find_contiguous_blocks, :build_block
+    private_class_method :find_contiguous_blocks, :process_block, :find_best_window, :calculate_avg_count, :build_block
   end
 end

--- a/app/views/availability/_suggested_slots.html.erb
+++ b/app/views/availability/_suggested_slots.html.erb
@@ -17,7 +17,7 @@
               <span class="text-base-content/60">（<%= slot[:slots] / 2 %>時間<%= slot[:slots].odd? ? "30分" : "" %>）</span>
             </div>
             <div class="mt-1 text-sm">
-              <span class="badge badge-info badge-sm">最低 <%= slot[:min_count] %>人 参加可能</span>
+              <span class="badge badge-info badge-sm">平均 <%= number_with_precision(slot[:avg_count], precision: 1) %>人 / 最低 <%= slot[:min_count] %>人 参加可能</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 概要

Issue #128で実装した開催候補日自動提案機能が実用的でない結果を返していた問題を修正しました。

## 問題点

- **現状**: 月〜水が全て「06:00〜24:00（18時間）最低1人参加可能」と表示される
- **原因**: 
  - ブロックの最大長に制限がなく、18時間のブロックが生成される
  - ソート基準が `min_count` → `slots（長さ）` で、長い低密度ブロックが優先される
  - 平均参加人数が考慮されていない
- **実際のデータ**: ヒートマップでは水曜16:00〜22:00に4-5人参加可能なのに候補に反映されない

## 改善内容

### 1. MAX_DURATION_SLOTS（4時間）の制限を追加
- 4時間を超える連続ブロックは、スライディングウィンドウで最も平均参加人数が高い4時間区間を抽出
- より現実的な時間枠で候補を提示

### 2. avg_count（平均参加人数）の導入
- 各候補枠の平均参加人数を計算
- ユーザーに「平均 X人 / 最低 N人 参加可能」と表示

### 3. ソート順の改善
- **変更前**: `min_count`降順 → `slots`降順
- **変更後**: `avg_count`降順 → `min_count`降順 → `slots`降順
- 参加人数が多い時間帯を優先

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `app/services/availability/suggest_slots.rb` | アルゴリズム改善（MAX制限、avg_count、スライディングウィンドウ） |
| `app/views/availability/_suggested_slots.html.erb` | avg_count表示追加 |
| `spec/services/availability/suggest_slots_spec.rb` | テスト更新（avg_count検証、長いブロック分割テスト追加） |

## テスト

- ✅ `spec/services/availability/suggest_slots_spec.rb`: 14 examples, 0 failures
- ✅ RuboCop: no offenses detected

## 期待される効果

- より実用的な時間帯（4時間以内）が提案される
- 参加人数が多い高密度時間帯が優先される
- ユーザーは平均と最低の両方の情報を見て判断できる

Closes #128