### PR TITLE
開催スコアの説明を改善し投票上限を調整

### DIFF
--- a/app/services/themes/hosting_ease_calculator.rb
+++ b/app/services/themes/hosting_ease_calculator.rb
@@ -10,7 +10,7 @@ module Themes
     WEIGHT_AVAILABILITY = 0.4 # 参加可能時間の重み
 
     # 正規化の上限値
-    MAX_VOTES = 20            # 投票数の上限（これ以上は1.0として扱う）
+    MAX_VOTES = 10            # 投票数の上限（これ以上は1.0として扱う）
     MAX_RSVP_RATE = 1.0       # 参加表明率の上限（100%）
     MAX_AVAILABILITY = 10     # 参加可能人数の上限（これ以上は1.0として扱う）
 

--- a/app/views/themes/_hosting_ease_score.html.erb
+++ b/app/views/themes/_hosting_ease_score.html.erb
@@ -1,6 +1,12 @@
 <div class="card bg-base-200 mt-4">
   <div class="card-body p-4">
-    <h3 class="card-title text-base">開催しやすさスコア</h3>
+    <div class="flex items-center justify-between">
+      <h3 class="card-title text-base">開催しやすさスコア</h3>
+    </div>
+
+    <p class="text-xs text-base-content/60 mt-1">
+      投票数・参加意欲・参加可能時間から算出した開催の実現可能性を示します（100点満点）
+    </p>
 
     <% if hosting_ease %>
       <div class="flex items-center gap-4">
@@ -41,6 +47,43 @@
             参加率: <%= (hosting_ease[:raw_data][:rsvp_rate] * 100).round(1) %>% |
             参加可能: <%= hosting_ease[:raw_data][:availability_count].round(1) %>人
           </div>
+        </div>
+      </div>
+
+      <!-- 満点条件の説明 -->
+      <div class="collapse collapse-arrow bg-base-100 mt-3">
+        <input type="checkbox" />
+        <div class="collapse-title text-xs font-medium">スコアの計算方法を見る</div>
+        <div class="collapse-content">
+          <table class="table table-xs">
+            <thead>
+              <tr>
+                <th>要素</th>
+                <th>最大点</th>
+                <th>満点になる条件</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>投票人気度</td>
+                <td>30点</td>
+                <td>投票数が10件以上</td>
+              </tr>
+              <tr>
+                <td>参加意欲</td>
+                <td>30点</td>
+                <td>参加表明率が100%</td>
+              </tr>
+              <tr>
+                <td>参加可能性</td>
+                <td>40点</td>
+                <td>参加可能人数が10人以上</td>
+              </tr>
+            </tbody>
+          </table>
+          <p class="text-xs text-base-content/60 mt-2">
+            ※ 各要素は上限値を超えても満点として扱われます
+          </p>
         </div>
       </div>
     <% else %>


### PR DESCRIPTION
## 概要
開催しやすさスコアの表示をよりわかりやすく改善しました。

## 変更内容
- スコアの説明文を追加（「投票数・参加意欲・参加可能時間から算出した開催の実現可能性」）
- 投票数の上限を20件から10件に変更
- 満点条件の詳細を折りたたみ表示で追加
  - 投票人気度: 10件以上で30点満点
  - 参加意欲: 100%で30点満点
  - 参加可能性: 10人以上で40点満点

## UI改善
- スコアの計算方法を折りたたみで表示
- 各要素の満点条件を表形式で明示
- 上限値を超えた場合の扱いを注釈で説明

## 検証方法
1. テーマ詳細ページにアクセス
2. 「開催しやすさスコア」カードの説明文を確認
3. 「スコアの計算方法を見る」を展開して詳細を確認

Closes #129